### PR TITLE
feat(engine): physics primitives + rule engine (60 tests)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,3 +5,103 @@ version = 4
 [[package]]
 name = "clarus-engine"
 version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -4,3 +4,7 @@ version = "0.1.0"
 edition = "2021"
 description = "Physics-based risk event engine for clarus"
 license = "MIT OR Apache-2.0"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod entity;
 pub mod physics;
+pub mod rules;

--- a/crates/engine/src/rules.rs
+++ b/crates/engine/src/rules.rs
@@ -1,0 +1,412 @@
+use serde::Deserialize;
+
+use crate::entity::{Entity, Vec2};
+use crate::physics::{euclidean_distance, relative_velocity, time_to_collision, zone_membership};
+
+// ── Public types ──────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum Severity {
+    Low,
+    Medium,
+    High,
+    Critical,
+}
+
+/// A evaluated condition type, parsed from the `condition` string in rules.json.
+#[derive(Debug, Clone)]
+pub enum Condition {
+    /// Fire when the distance between any two entities drops below threshold (metres).
+    DistanceLt(f32),
+    /// Fire when the time-to-collision between any two approaching entities drops below threshold (s).
+    TtcLt(f32),
+    /// Fire when any entity's position is inside the given polygon.
+    ZoneMember(Vec<Vec2>),
+}
+
+#[derive(Debug, Clone)]
+pub struct Rule {
+    pub rule_id: String,
+    pub condition: Condition,
+    pub severity: Severity,
+    pub regulation: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct RiskEvent {
+    pub rule_id: String,
+    pub severity: Severity,
+    /// Exact regulation clause that was violated.
+    pub regulation: String,
+    /// IDs of the entities involved (two for proximity/TTC rules, one for zone rules).
+    pub entity_ids: Vec<String>,
+    /// The physical measurement that triggered the event (distance in m, TTC in s, or 1.0 for zone).
+    pub measured_value: f32,
+    /// The threshold that was breached.
+    pub threshold: f32,
+    pub timestamp_ms: u64,
+}
+
+// ── JSON loading ──────────────────────────────────────────────────────────────
+
+/// Raw rule as it appears in rules.json — condition is still a string.
+#[derive(Debug, Deserialize)]
+struct RuleJson {
+    rule_id: String,
+    condition: String,
+    severity: Severity,
+    regulation: String,
+    /// Required for `zone_member` conditions; polygon vertices as [x, y] pairs.
+    zone: Option<Vec<[f32; 2]>>,
+}
+
+/// Load and parse rules from a JSON string (contents of rules.json).
+///
+/// # Errors
+/// Returns an error string if the JSON is malformed or a condition cannot be parsed.
+pub fn load_rules(json: &str) -> Result<Vec<Rule>, String> {
+    let raws: Vec<RuleJson> =
+        serde_json::from_str(json).map_err(|e| format!("JSON parse error: {e}"))?;
+    raws.into_iter().map(rule_from_json).collect()
+}
+
+fn rule_from_json(raw: RuleJson) -> Result<Rule, String> {
+    let condition = parse_condition(&raw.condition, raw.zone)?;
+    Ok(Rule {
+        rule_id: raw.rule_id,
+        condition,
+        severity: raw.severity,
+        regulation: raw.regulation,
+    })
+}
+
+fn parse_condition(s: &str, zone: Option<Vec<[f32; 2]>>) -> Result<Condition, String> {
+    let s = s.trim();
+    if s == "zone_member" {
+        let verts = zone.ok_or_else(|| {
+            "condition 'zone_member' requires a 'zone' polygon in the rule".to_string()
+        })?;
+        let polygon = verts.into_iter().map(|[x, y]| Vec2::new(x, y)).collect();
+        return Ok(Condition::ZoneMember(polygon));
+    }
+    if let Some(rest) = s.strip_prefix("distance < ") {
+        let t: f32 = rest.trim().parse().map_err(|_| format!("invalid threshold in '{s}'"))?;
+        return Ok(Condition::DistanceLt(t));
+    }
+    if let Some(rest) = s.strip_prefix("ttc < ") {
+        let t: f32 = rest.trim().parse().map_err(|_| format!("invalid threshold in '{s}'"))?;
+        return Ok(Condition::TtcLt(t));
+    }
+    Err(format!("unknown condition expression: '{s}'"))
+}
+
+// ── Evaluation ────────────────────────────────────────────────────────────────
+
+/// Evaluate all rules against the current entity snapshot.
+/// Returns one `RiskEvent` per (rule, entity-pair or entity) that breaches a threshold.
+pub fn evaluate(rules: &[Rule], entities: &[Entity], timestamp_ms: u64) -> Vec<RiskEvent> {
+    let mut events = Vec::new();
+
+    for rule in rules {
+        match &rule.condition {
+            Condition::DistanceLt(threshold) => {
+                for i in 0..entities.len() {
+                    for j in (i + 1)..entities.len() {
+                        let dist = euclidean_distance(&entities[i], &entities[j]);
+                        if dist < *threshold {
+                            events.push(RiskEvent {
+                                rule_id: rule.rule_id.clone(),
+                                severity: rule.severity.clone(),
+                                regulation: rule.regulation.clone(),
+                                entity_ids: vec![
+                                    entities[i].id.clone(),
+                                    entities[j].id.clone(),
+                                ],
+                                measured_value: dist,
+                                threshold: *threshold,
+                                timestamp_ms,
+                            });
+                        }
+                    }
+                }
+            }
+            Condition::TtcLt(threshold) => {
+                for i in 0..entities.len() {
+                    for j in (i + 1)..entities.len() {
+                        let dist = euclidean_distance(&entities[i], &entities[j]);
+                        let rv = relative_velocity(&entities[i], &entities[j]);
+                        let ttc = time_to_collision(dist, rv);
+                        if ttc < *threshold {
+                            events.push(RiskEvent {
+                                rule_id: rule.rule_id.clone(),
+                                severity: rule.severity.clone(),
+                                regulation: rule.regulation.clone(),
+                                entity_ids: vec![
+                                    entities[i].id.clone(),
+                                    entities[j].id.clone(),
+                                ],
+                                measured_value: ttc,
+                                threshold: *threshold,
+                                timestamp_ms,
+                            });
+                        }
+                    }
+                }
+            }
+            Condition::ZoneMember(polygon) => {
+                for entity in entities {
+                    if zone_membership(entity.position.clone(), polygon) {
+                        events.push(RiskEvent {
+                            rule_id: rule.rule_id.clone(),
+                            severity: rule.severity.clone(),
+                            regulation: rule.regulation.clone(),
+                            entity_ids: vec![entity.id.clone()],
+                            measured_value: 1.0,
+                            threshold: 0.0,
+                            timestamp_ms,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    events
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::entity::{Entity, EntityClass, Vec2};
+
+    fn entity(id: &str, x: f32, y: f32, vx: f32, vy: f32) -> Entity {
+        Entity {
+            id: id.into(),
+            class: EntityClass::Forklift,
+            position: Vec2::new(x, y),
+            velocity: Vec2::new(vx, vy),
+            timestamp_ms: 0,
+        }
+    }
+
+    const SG_PORT_SAFETY_JSON: &str = r#"[
+        {"rule_id":"MPA_CLEARANCE_5M","condition":"distance < 5.0","severity":"HIGH","regulation":"MPA Port Safety Circular No. 14 of 2023 §3.1"},
+        {"rule_id":"EXCLUSION_ZONE_BREACH","condition":"zone_member","severity":"CRITICAL","regulation":"PSA Terminal Safety Rules §4.2","zone":[[0,0],[10,0],[10,10],[0,10]]},
+        {"rule_id":"TTC_CRITICAL_3S","condition":"ttc < 3.0","severity":"HIGH","regulation":"MPA Port Safety Circular No. 14 of 2023 §3.2"}
+    ]"#;
+
+    // ── load_rules ────────────────────────────────────────────────────────
+
+    #[test]
+    fn load_parses_three_rules() {
+        let rules = load_rules(SG_PORT_SAFETY_JSON).unwrap();
+        assert_eq!(rules.len(), 3);
+    }
+
+    #[test]
+    fn load_rule_ids_correct() {
+        let rules = load_rules(SG_PORT_SAFETY_JSON).unwrap();
+        assert_eq!(rules[0].rule_id, "MPA_CLEARANCE_5M");
+        assert_eq!(rules[1].rule_id, "EXCLUSION_ZONE_BREACH");
+        assert_eq!(rules[2].rule_id, "TTC_CRITICAL_3S");
+    }
+
+    #[test]
+    fn load_severities_correct() {
+        let rules = load_rules(SG_PORT_SAFETY_JSON).unwrap();
+        assert_eq!(rules[0].severity, Severity::High);
+        assert_eq!(rules[1].severity, Severity::Critical);
+    }
+
+    #[test]
+    fn load_condition_distance_threshold() {
+        let rules = load_rules(SG_PORT_SAFETY_JSON).unwrap();
+        match &rules[0].condition {
+            Condition::DistanceLt(t) => assert!((*t - 5.0).abs() < 1e-5),
+            other => panic!("expected DistanceLt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_condition_zone_has_polygon() {
+        let rules = load_rules(SG_PORT_SAFETY_JSON).unwrap();
+        match &rules[1].condition {
+            Condition::ZoneMember(polygon) => assert_eq!(polygon.len(), 4),
+            other => panic!("expected ZoneMember, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_condition_ttc_threshold() {
+        let rules = load_rules(SG_PORT_SAFETY_JSON).unwrap();
+        match &rules[2].condition {
+            Condition::TtcLt(t) => assert!((*t - 3.0).abs() < 1e-5),
+            other => panic!("expected TtcLt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_invalid_json_returns_error() {
+        assert!(load_rules("{not json}").is_err());
+    }
+
+    #[test]
+    fn load_zone_member_without_zone_returns_error() {
+        let json = r#"[{"rule_id":"X","condition":"zone_member","severity":"HIGH","regulation":"r"}]"#;
+        assert!(load_rules(json).is_err());
+    }
+
+    #[test]
+    fn load_unknown_condition_returns_error() {
+        let json = r#"[{"rule_id":"X","condition":"unknown_op > 5","severity":"HIGH","regulation":"r"}]"#;
+        assert!(load_rules(json).is_err());
+    }
+
+    // ── evaluate — distance ───────────────────────────────────────────────
+
+    #[test]
+    fn evaluate_distance_breach_fires_event() {
+        let rules = load_rules(SG_PORT_SAFETY_JSON).unwrap();
+        let entities = vec![
+            entity("FL-01", 0.0, 0.0, 1.4, 0.0),
+            entity("W-03", 3.2, 0.0, 0.0, 0.0),
+        ];
+        let events = evaluate(&rules, &entities, 1000);
+        let evt = events.iter().find(|e| e.rule_id == "MPA_CLEARANCE_5M").unwrap();
+        assert!((evt.measured_value - 3.2).abs() < 1e-4);
+        assert_eq!(evt.threshold, 5.0);
+        assert_eq!(evt.entity_ids, vec!["FL-01", "W-03"]);
+        assert_eq!(evt.timestamp_ms, 1000);
+    }
+
+    #[test]
+    fn evaluate_distance_no_breach_when_safe() {
+        let rules = load_rules(SG_PORT_SAFETY_JSON).unwrap();
+        let entities = vec![
+            entity("FL-01", 0.0, 0.0, 0.0, 0.0),
+            entity("W-03", 6.0, 0.0, 0.0, 0.0),
+        ];
+        let events = evaluate(&rules, &entities, 0);
+        assert!(!events.iter().any(|e| e.rule_id == "MPA_CLEARANCE_5M"));
+    }
+
+    #[test]
+    fn evaluate_distance_multiple_pairs() {
+        // Three entities, two pairs breach clearance
+        let rules = load_rules(SG_PORT_SAFETY_JSON).unwrap();
+        let entities = vec![
+            entity("A", 0.0, 0.0, 0.0, 0.0),
+            entity("B", 1.0, 0.0, 0.0, 0.0), // A-B: 1m → breach
+            entity("C", 2.0, 0.0, 0.0, 0.0), // A-C: 2m → breach; B-C: 1m → breach
+        ];
+        let events: Vec<_> = evaluate(&rules, &entities, 0)
+            .into_iter()
+            .filter(|e| e.rule_id == "MPA_CLEARANCE_5M")
+            .collect();
+        assert_eq!(events.len(), 3);
+    }
+
+    // ── evaluate — zone ───────────────────────────────────────────────────
+
+    #[test]
+    fn evaluate_zone_breach_fires_for_entity_inside() {
+        let rules = load_rules(SG_PORT_SAFETY_JSON).unwrap();
+        let entities = vec![entity("V-01", 5.0, 5.0, 0.0, 0.0)]; // inside [0,0]-[10,10]
+        let events = evaluate(&rules, &entities, 0);
+        assert!(events.iter().any(|e| e.rule_id == "EXCLUSION_ZONE_BREACH"));
+    }
+
+    #[test]
+    fn evaluate_zone_no_breach_when_outside() {
+        let rules = load_rules(SG_PORT_SAFETY_JSON).unwrap();
+        let entities = vec![entity("V-01", 15.0, 5.0, 0.0, 0.0)]; // outside zone
+        let events = evaluate(&rules, &entities, 0);
+        assert!(!events.iter().any(|e| e.rule_id == "EXCLUSION_ZONE_BREACH"));
+    }
+
+    // ── evaluate — TTC ────────────────────────────────────────────────────
+
+    #[test]
+    fn evaluate_ttc_breach_fires_when_fast_approach() {
+        let rules = load_rules(SG_PORT_SAFETY_JSON).unwrap();
+        // 2m gap, 5 m/s approach → TTC = 0.4 s < 3.0 s
+        let entities = vec![
+            entity("FL-01", 0.0, 0.0, 5.0, 0.0),
+            entity("W-03", 2.0, 0.0, 0.0, 0.0),
+        ];
+        let events = evaluate(&rules, &entities, 0);
+        assert!(events.iter().any(|e| e.rule_id == "TTC_CRITICAL_3S"));
+    }
+
+    #[test]
+    fn evaluate_ttc_no_breach_when_slow_approach() {
+        let rules = load_rules(SG_PORT_SAFETY_JSON).unwrap();
+        // 20m gap, 1 m/s approach → TTC = 20 s > 3.0 s
+        let entities = vec![
+            entity("FL-01", 0.0, 0.0, 1.0, 0.0),
+            entity("W-03", 20.0, 0.0, 0.0, 0.0),
+        ];
+        let events = evaluate(&rules, &entities, 0);
+        assert!(!events.iter().any(|e| e.rule_id == "TTC_CRITICAL_3S"));
+    }
+
+    #[test]
+    fn evaluate_ttc_no_breach_when_receding() {
+        let rules = load_rules(SG_PORT_SAFETY_JSON).unwrap();
+        // Moving away — TTC = ∞
+        let entities = vec![
+            entity("FL-01", 0.0, 0.0, -3.0, 0.0),
+            entity("W-03", 2.0, 0.0, 0.0, 0.0),
+        ];
+        let events = evaluate(&rules, &entities, 0);
+        assert!(!events.iter().any(|e| e.rule_id == "TTC_CRITICAL_3S"));
+    }
+
+    // ── evaluate — empty inputs ───────────────────────────────────────────
+
+    #[test]
+    fn evaluate_empty_entities_returns_no_events() {
+        let rules = load_rules(SG_PORT_SAFETY_JSON).unwrap();
+        assert!(evaluate(&rules, &[], 0).is_empty());
+    }
+
+    #[test]
+    fn evaluate_empty_rules_returns_no_events() {
+        let entities = vec![entity("A", 0.0, 0.0, 1.0, 0.0)];
+        assert!(evaluate(&[], &entities, 0).is_empty());
+    }
+
+    // ── Scenario: roadmap demo ────────────────────────────────────────────
+    // Forklift FL-01 at (0,0) moving at 1.4 m/s toward Worker W-03 at (3.2,0).
+    // Expects MPA_CLEARANCE_5M and TTC_CRITICAL_3S to fire.
+
+    #[test]
+    fn scenario_roadmap_demo_fires_clearance_and_ttc() {
+        let rules = load_rules(SG_PORT_SAFETY_JSON).unwrap();
+        let entities = vec![
+            entity("FL-01", 0.0, 0.0, 1.4, 0.0),
+            entity("W-03", 3.2, 0.0, 0.0, 0.0),
+        ];
+        let events = evaluate(&rules, &entities, 14230000);
+        let rule_ids: Vec<&str> = events.iter().map(|e| e.rule_id.as_str()).collect();
+        assert!(rule_ids.contains(&"MPA_CLEARANCE_5M"), "clearance rule should fire");
+        assert!(rule_ids.contains(&"TTC_CRITICAL_3S"), "TTC rule should fire");
+    }
+
+    #[test]
+    fn scenario_roadmap_demo_clearance_event_values() {
+        let rules = load_rules(SG_PORT_SAFETY_JSON).unwrap();
+        let entities = vec![
+            entity("FL-01", 0.0, 0.0, 1.4, 0.0),
+            entity("W-03", 3.2, 0.0, 0.0, 0.0),
+        ];
+        let events = evaluate(&rules, &entities, 14230000);
+        let evt = events.iter().find(|e| e.rule_id == "MPA_CLEARANCE_5M").unwrap();
+        assert!((evt.measured_value - 3.2).abs() < 1e-4);
+        assert_eq!(evt.severity, Severity::High);
+        assert!(evt.regulation.contains("§3.1"));
+    }
+}

--- a/docs/roadmap1-poc.md
+++ b/docs/roadmap1-poc.md
@@ -115,14 +115,14 @@ Goal: `EntityStream` → `RiskEvent`. No vision, no LLM. Deterministic and testa
 **Tasks:**
 
 - [ ] `crates/input-adapter/src/unity_udp.rs` — UDP receiver, deserialise JSON into `EntityStream`
-- [ ] `crates/engine/src/physics.rs` — implement:
+- [x] `crates/engine/src/physics.rs` — implement: ([PR #7](https://github.com/edgesentry/clarus/pull/7), 39 tests passing)
   - `euclidean_distance(a: &Entity, b: &Entity) -> f32`
   - `relative_velocity(a: &Entity, b: &Entity) -> f32`
   - `braking_distance(speed: f32, entity_class: EntityClass) -> f32`
   - `time_to_collision(distance: f32, approach_rate: f32) -> f32`
   - `zone_membership(pos: Vec2, polygon: &[Vec2]) -> bool`
-- [ ] `crates/engine/src/rules.rs` — load `rules.json`, evaluate each rule against `EntityStream`, emit `RiskEvent`
-- [ ] `profiles/sg-port-safety/rules.json` — encode first 3 rules:
+- [x] `crates/engine/src/rules.rs` — load `rules.json`, evaluate each rule against `EntityStream`, emit `RiskEvent` ([PR #8](https://github.com/edgesentry/clarus/pull/8), 21 tests passing)
+- [x] `profiles/sg-port-safety/rules.json` — 3 seed rules encoded ([PR #8](https://github.com/edgesentry/clarus/pull/8)):
   ```json
   { "rule_id": "MPA_CLEARANCE_5M",      "condition": "distance < 5.0",  "severity": "HIGH",     "regulation": "MPA Port Safety Circular No. 14 of 2023 §3.1" }
   { "rule_id": "EXCLUSION_ZONE_BREACH", "condition": "zone_member",     "severity": "CRITICAL", "regulation": "PSA Terminal Safety Rules §4.2" }

--- a/profiles/sg-port-safety/rules.json
+++ b/profiles/sg-port-safety/rules.json
@@ -1,0 +1,21 @@
+[
+  {
+    "rule_id": "MPA_CLEARANCE_5M",
+    "condition": "distance < 5.0",
+    "severity": "HIGH",
+    "regulation": "MPA Port Safety Circular No. 14 of 2023 §3.1"
+  },
+  {
+    "rule_id": "EXCLUSION_ZONE_BREACH",
+    "condition": "zone_member",
+    "severity": "CRITICAL",
+    "regulation": "PSA Terminal Safety Rules §4.2",
+    "zone": [[0, 0], [10, 0], [10, 10], [0, 10]]
+  },
+  {
+    "rule_id": "TTC_CRITICAL_3S",
+    "condition": "ttc < 3.0",
+    "severity": "HIGH",
+    "regulation": "MPA Port Safety Circular No. 14 of 2023 §3.2"
+  }
+]


### PR DESCRIPTION
Closes #3
Closes #4

Supersedes #7 and #8 (rebased cleanly onto main).

## Why this matters

This is the core of clarus's value proposition: **regulations as code, evaluated at machine speed**.

Every existing safety AI (Protex AI, viAct, Visionify) detects that two objects are geometrically close. This engine answers *why* a proximity is dangerous — by evaluating it against the exact clause of the regulation that defines the threshold. The output is admissible evidence in a regulatory investigation. A video clip is not.

When MPA amends a Circular: update `rules.json`. No model retraining, no redeployment.

## Physics (`crates/engine/src/physics.rs` + `entity.rs`) — 39 tests

| Function | Description |
|---|---|
| `euclidean_distance` | Straight-line gap in metres |
| `relative_velocity` | Approach rate in m/s (positive = closing) |
| `braking_distance` | v²/2a; Person = 0.0 (instant stop, conservative) |
| `time_to_collision` | seconds; `f32::INFINITY` when not approaching |
| `zone_membership` | Ray-casting point-in-polygon |

`EntityClass` with validated service-brake deceleration values (Forklift 1.5 m/s², Vessel 0.05 m/s², etc.)

## Rule engine (`crates/engine/src/rules.rs`) — 21 tests

- **`load_rules(json)`** — parses rules.json; condition strings parsed into typed `Condition` enum at load time; errors on unknown condition or missing zone polygon
- **`evaluate(rules, entities, timestamp_ms)`** — O(n²) pair check for distance/TTC; per-entity for zone membership

## Profile

`profiles/sg-port-safety/rules.json` — 3 seed rules:

| rule_id | condition | severity | regulation |
|---|---|---|---|
| `MPA_CLEARANCE_5M` | distance < 5.0 m | HIGH | MPA Port Safety Circular No. 14 of 2023 §3.1 |
| `EXCLUSION_ZONE_BREACH` | zone_member | CRITICAL | PSA Terminal Safety Rules §4.2 |
| `TTC_CRITICAL_3S` | ttc < 3.0 s | HIGH | MPA Port Safety Circular No. 14 of 2023 §3.2 |

## Tests

```
cargo test
test result: ok. 60 passed; 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)