### PR TITLE
fix(input-adapter): suppress dead_code warning on FileReplayAdapter::reset

### DIFF
--- a/crates/input-adapter/src/file_replay.rs
+++ b/crates/input-adapter/src/file_replay.rs
@@ -66,6 +66,7 @@ impl FileReplayAdapter {
     }
 
     /// Reset replay to the beginning.
+    #[allow(dead_code)]
     pub fn reset(&mut self) {
         self.cursor = 0;
     }


### PR DESCRIPTION
## Summary

- `FileReplayAdapter::reset` is a public method tested by `reset_replays_from_start`, but Rust's `dead_code` lint ignores `#[cfg(test)]` call sites and emits a spurious warning during `cargo build`
- Added `#[allow(dead_code)]` to silence the warning without removing the method or changing any behaviour

## Test plan

- [ ] `cargo build --bin clarus` produces no warnings
- [ ] `./scripts/test-e2e.sh --no-explain --no-udp` — all stages pass (97 unit tests, CSV replay, rule spot-checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)