### PR TITLE
docs(roadmap): add webcam / smartphone IP camera as Phase 0 dev input source

### DIFF
--- a/docs/roadmap1-poc.md
+++ b/docs/roadmap1-poc.md
@@ -82,6 +82,7 @@ Categories are defined by **data modality** (what the signal is), not by use cas
 | Source | Phase | Notes |
 |---|---|---|
 | Video file upload | Phase 0 demo | Offline analysis; same adapter as RTSP without live streaming |
+| Webcam / smartphone IP camera | Phase 0 dev | Home miniature verification; same YOLOv8 + tracker pipeline as RTSP; scale defined in `profiles/home-test/params.toml` |
 | RTSP stream — IP camera | Phase 2 | Existing CCTV; vision model (YOLOv8) + tracker → EntityStream |
 | RTSP stream — thermal camera | Phase 2 | Same adapter as IP camera; perimeter / night operations |
 


### PR DESCRIPTION
## Summary

- Adds webcam / smartphone IP camera as a Phase 0 dev input source in the roadmap
- Uses the same YOLOv8 + tracker pipeline as RTSP; scale parameters defined in `profiles/home-test/params.toml`
- Intended for home miniature environment verification before on-site deployment

## Test plan

- [ ] Docs-only change — no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)