### PR TITLE
fix(ci): correct typo in dependency-submission action hash

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -18,4 +18,4 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Submit dependency snapshot
-        uses: advanced-security/component-detection-dependency-submission-action@9c110eb34dee187cd9eca76a662b9f6a0ed22927  # v0.1.1
+        uses: advanced-security/component-detection-dependency-submission-action@9c110eb34dee187cd9eca76a652b9f6a0ed22927  # v0.1.1


### PR DESCRIPTION
Fixes `662` → `652` in the pinned action hash — caused `Unable to find version` error in the Dependency Submission job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)