### PR TITLE
feat(unity): Scene 2 vessel/zone scripts — closes #45

### DIFF
--- a/unity/README.md
+++ b/unity/README.md
@@ -7,7 +7,7 @@ Two scenes for the PIER71 / CAP Vista demo video.
 | **Scene 1** — Port Safety | Forklift approaches pedestrian in terminal yard | `profiles/demo` |
 | **Scene 2** — Maritime Security | Vessel approaches Singapore restricted zone | `profiles/sg-maritime-security` |
 
-**Unity version:** 2023 LTS (2023.2.x or later)  
+**Unity version:** Unity 6 (6000.x) — recommended and tested  
 **No additional packages required** — uses only the Unity standard library (`UdpClient` is in `System.Net.Sockets`).
 
 ## Scripts

--- a/unity/README.md
+++ b/unity/README.md
@@ -1,9 +1,24 @@
 # clarus Unity Scene — Setup Guide
 
-Minimal Unity scene that streams entity positions to clarus via UDP at 10 Hz.
+Two scenes for the PIER71 / CAP Vista demo video.
+
+| Scene | Description | Profile |
+|-------|-------------|---------|
+| **Scene 1** — Port Safety | Forklift approaches pedestrian in terminal yard | `profiles/demo` |
+| **Scene 2** — Maritime Security | Vessel approaches Singapore restricted zone | `profiles/sg-maritime-security` |
 
 **Unity version:** 2023 LTS (2023.2.x or later)  
-**No additional packages required** — uses only the Unity standard library (UdpClient is in `System.Net.Sockets`).
+**No additional packages required** — uses only the Unity standard library (`UdpClient` is in `System.Net.Sockets`).
+
+## Scripts
+
+| Script | Attach to | Purpose |
+|--------|-----------|---------|
+| `ClarusEntity.cs` | Every tracked GameObject | Marks entity with ID + class |
+| `ClarusUdpExporter.cs` | One empty manager object | Broadcasts all entities via UDP |
+| `ForkliftPath.cs` | Forklift object (Scene 1) | Straight-line approach path |
+| `VesselPath.cs` | Vessel object (Scene 2) | East-bound approach to zone |
+| `ZoneBoundary.cs` | Empty zone object (Scene 2) | Draws restricted zone rectangle |
 
 ---
 
@@ -145,6 +160,78 @@ Run the automated end-to-end test to confirm:
 
 ---
 
+---
+
+## Scene 2 — Maritime Security (CAP Vista Tier-2)
+
+Vessel V-001 approaches Singapore restricted zone at 2 m/s. Zone entry fires `RESTRICTED_ZONE_APPROACH HIGH` at x = 300 m (≈ t = 150 s).
+
+### Build the scene
+
+**Ground/water plane**
+- 3D Object → Plane, scale (70, 1, 70) — covers 700 × 700 m
+- Set material to a blue water shader or flat blue colour
+
+**Vessel (V-001)**
+- 3D Object → Cube, scale (20, 5, 8) — rough vessel silhouette
+- Name: `Vessel_V001`
+- Position: (0, 2.5, 350) — starts at world (0, 350), centre of zone y-range
+- Add `ClarusEntity`: `entityId = "V-001"`, `entityClass = Vessel`
+- Add `VesselPath`: leave defaults (start 0 m, end 700 m, speed 2 m/s)
+
+**Restricted zone**
+- Hierarchy → Create Empty, name `RestrictedZone`
+- Add `ZoneBoundary`: xMin=300, xMax=600, zMin=200, zMax=500
+- The zone outline and label appear automatically in Play mode
+
+**Camera**
+- Position: (350, 600, 350) — top-down, looking straight down
+- Rotation: (90, 0, 0)
+- Orthographic size: 380 — frames the 700 m world
+
+**Manager**
+- Create Empty → `ClarusManager`
+- Add `ClarusUdpExporter`: targetPort=9000, tickHz=10
+
+### Run with clarus
+
+```bash
+# Terminal 1 — start eds UDP listener
+eds ingest stream \
+  --source udp://127.0.0.1:9000 \
+  --profile profiles/sg-maritime-security \
+  --out /tmp/vessel-events.jsonl
+
+# Press Play in Unity — vessel moves east at 2 m/s
+# At t ≈ 150 s, clarus prints:
+# [HIGH] RESTRICTED_ZONE_APPROACH — entities: ["V-001"] — value: 1.0 (zone member)
+```
+
+### Acceptance criteria
+
+1. Vessel starts at x = 0, moves east at 2 m/s
+2. At x = 300 m: `RESTRICTED_ZONE_APPROACH HIGH` fires in clarus
+3. Zone boundary turns red (`ZoneBoundary.OnAlert(true)`)
+4. Event shows: `regulation = "Singapore Infrastructure Protection Act (Cap. 136A) §18"`
+
+---
+
+## Demo video script (5 min, 1080p)
+
+| Time | Content |
+|------|---------|
+| 0:00–0:20 | Scene 1 overview — terminal yard, forklift + worker visible |
+| 0:20–1:30 | Forklift approaches slowly → no alert. Accelerates → `MPA_CLEARANCE_5M HIGH` fires |
+| 1:30–2:00 | TTC drops → `TTC_CRITICAL_3S HIGH` fires, regulation citation shown |
+| 2:00–2:45 | Click event → LLM explanation panel opens |
+| 2:45–3:30 | "Generate PDF Report" → report opens, audit chain → ✓ verified |
+| 3:30–3:45 | Switch to Scene 2 (maritime) |
+| 3:45–5:00 | Vessel approaches from west → crosses zone boundary → `RESTRICTED_ZONE_APPROACH HIGH` |
+
+Export as `demo-edgesentry-2026.mp4` at 1080p 30fps.
+
+---
+
 ## Troubleshooting
 
 | Symptom | Fix |
@@ -153,3 +240,6 @@ Run the automated end-to-end test to confirm:
 | `Port already in use` | Change `targetPort` in the exporter and `--input udp://127.0.0.1:<port>` in clarus |
 | Velocity always 0 | Check that `tickHz` in the exporter matches the actual tick rate; verify `ForkliftPath` is moving the transform |
 | Wrong entity class | `EntityClass` enum in `ClarusEntity.cs` must match the variants in `crates/engine/src/entity.rs` exactly |
+| Vessel at wrong position | Check `VesselPath.startPosition` — Unity z = world y, so z should be 350 for centre of zone |
+| Zone not visible | Ensure `ZoneBoundary` script is on an active GameObject; `LineRenderer` requires a scene with a camera |
+| Alert fires too early / late | Confirm `zoneEntryX = 300` in `VesselPath` and zone polygon in `sg-maritime-security/rules.json` matches |

--- a/unity/Scripts/ClarusUdpExporter.cs
+++ b/unity/Scripts/ClarusUdpExporter.cs
@@ -67,7 +67,7 @@ public class ClarusUdpExporter : MonoBehaviour
 
     private void SendTick()
     {
-        var entities = FindObjectsByType<ClarusEntity>(FindObjectsSortMode.None);
+        var entities = FindObjectsByType<ClarusEntity>(FindObjectsInactive.Exclude, FindObjectsSortMode.None);
         if (entities.Length == 0) return;
 
         long timestampMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();

--- a/unity/Scripts/ClarusUdpExporter.cs
+++ b/unity/Scripts/ClarusUdpExporter.cs
@@ -67,7 +67,7 @@ public class ClarusUdpExporter : MonoBehaviour
 
     private void SendTick()
     {
-        var entities = FindObjectsOfType<ClarusEntity>();
+        var entities = FindObjectsByType<ClarusEntity>(FindObjectsSortMode.None);
         if (entities.Length == 0) return;
 
         long timestampMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();

--- a/unity/Scripts/ClarusUdpExporter.cs
+++ b/unity/Scripts/ClarusUdpExporter.cs
@@ -67,7 +67,7 @@ public class ClarusUdpExporter : MonoBehaviour
 
     private void SendTick()
     {
-        var entities = FindObjectsByType<ClarusEntity>(FindObjectsInactive.Exclude, FindObjectsSortMode.None);
+        var entities = FindObjectsByType<ClarusEntity>(FindObjectsInactive.Exclude);
         if (entities.Length == 0) return;
 
         long timestampMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();

--- a/unity/Scripts/VesselPath.cs
+++ b/unity/Scripts/VesselPath.cs
@@ -1,0 +1,95 @@
+using UnityEngine;
+
+/// Moves a vessel east at constant speed toward a restricted zone.
+///
+/// Coordinate mapping matches the sg-maritime-security scenario:
+///   World (x, y):  x = east (metres), y = north (metres)
+///   Unity (x, z):  Unity x → world x,  Unity z → world y
+///
+/// Default path: x = 0 → 700 m at 2 m/s, y = 350 m (centre of zone).
+/// Zone polygon: x ∈ [300, 600], y ∈ [200, 500] (from sg-maritime-security/rules.json).
+/// RESTRICTED_ZONE_APPROACH fires when the vessel crosses x = 300 m (≈ t = 150 s).
+///
+/// Attach to the vessel GameObject alongside ClarusEntity.
+public class VesselPath : MonoBehaviour
+{
+    [Tooltip("World-space start position (x=east, z=north in Unity)")]
+    public Vector3 startPosition = new Vector3(0f, 0f, 350f);
+
+    [Tooltip("World-space end position")]
+    public Vector3 endPosition = new Vector3(700f, 0f, 350f);
+
+    [Tooltip("Speed in m/s — matches vessel_zone_approach.csv (2 m/s)")]
+    public float speed = 2f;
+
+    [Tooltip("Pause at end (seconds) before looping back to start")]
+    public float pauseAtEnd = 5f;
+
+    [Tooltip("x-coordinate where RESTRICTED_ZONE_APPROACH fires (for logging)")]
+    public float zoneEntryX = 300f;
+
+    private float _t = 0f;
+    private bool _pausing = false;
+    private float _pauseTimer = 0f;
+    private bool _alertLogged = false;
+
+    void Start()
+    {
+        transform.position = startPosition;
+    }
+
+    void Update()
+    {
+        if (_pausing)
+        {
+            _pauseTimer += Time.deltaTime;
+            if (_pauseTimer >= pauseAtEnd)
+            {
+                _pausing = false;
+                _pauseTimer = 0f;
+                _t = 0f;
+                _alertLogged = false;
+                transform.position = startPosition;
+            }
+            return;
+        }
+
+        float totalDist = Vector3.Distance(startPosition, endPosition);
+        _t += speed * Time.deltaTime / totalDist;
+        _t = Mathf.Clamp01(_t);
+        transform.position = Vector3.Lerp(startPosition, endPosition, _t);
+
+        // Log zone entry once per pass (informational only — clarus fires the real alert)
+        if (!_alertLogged && transform.position.x >= zoneEntryX)
+        {
+            _alertLogged = true;
+            Debug.Log($"[VesselPath] Zone boundary crossed at x={transform.position.x:F1} m " +
+                      $"— RESTRICTED_ZONE_APPROACH should fire in clarus");
+        }
+
+        if (_t >= 1f) _pausing = true;
+    }
+
+    // Draw the zone polygon and vessel path in the Scene view for alignment.
+    void OnDrawGizmos()
+    {
+        // Vessel path
+        Gizmos.color = Color.cyan;
+        Gizmos.DrawLine(startPosition, endPosition);
+        Gizmos.DrawSphere(startPosition, 3f);
+
+        // Zone boundary (sg-maritime-security default: x ∈ [300,600], y ∈ [200,500])
+        Gizmos.color = new Color(1f, 0.2f, 0.2f, 0.5f);
+        Vector3 zoneMin = new Vector3(300f, 0f, 200f);
+        Vector3 zoneMax = new Vector3(600f, 0f, 500f);
+        Vector3 center  = (zoneMin + zoneMax) / 2f;
+        Vector3 size    = new Vector3(zoneMax.x - zoneMin.x, 0.1f, zoneMax.z - zoneMin.z);
+        Gizmos.DrawCube(center, size);
+        Gizmos.color = Color.red;
+        Gizmos.DrawWireCube(center, size);
+
+        // Zone entry line
+        Gizmos.color = Color.yellow;
+        Gizmos.DrawLine(new Vector3(zoneEntryX, 0f, 150f), new Vector3(zoneEntryX, 0f, 550f));
+    }
+}

--- a/unity/Scripts/ZoneBoundary.cs
+++ b/unity/Scripts/ZoneBoundary.cs
@@ -1,0 +1,83 @@
+using UnityEngine;
+
+/// Visualises a rectangular restricted zone in the scene using a LineRenderer.
+///
+/// Place on an empty GameObject. Set corners to match the zone polygon in
+/// sg-maritime-security/rules.json:
+///   [[300,200],[600,200],[600,500],[300,500]]
+///
+/// In Unity coordinates (x = world x, z = world y):
+///   (300, 0, 200) → (600, 0, 200) → (600, 0, 500) → (300, 0, 500) → back
+///
+/// The zone turns red when an alert is active. Wire up OnAlert() via your
+/// alert UI script, or leave it static red for the demo recording.
+public class ZoneBoundary : MonoBehaviour
+{
+    [Header("Zone corners (world metres: x=east, z=north)")]
+    public float xMin = 300f;
+    public float xMax = 600f;
+    public float zMin = 200f;
+    public float zMax = 500f;
+
+    [Header("Appearance")]
+    public Color normalColor = new Color(1f, 0.3f, 0.3f, 0.6f);
+    public Color alertColor  = new Color(1f, 0f,   0f,   1.0f);
+    public float lineWidth   = 2f;
+
+    [Header("Label")]
+    public bool showLabel = true;
+
+    private LineRenderer _lr;
+    private bool _alertActive = false;
+
+    void Awake()
+    {
+        _lr = gameObject.AddComponent<LineRenderer>();
+        _lr.loop = true;
+        _lr.positionCount = 4;
+        _lr.startWidth = lineWidth;
+        _lr.endWidth   = lineWidth;
+        _lr.useWorldSpace = true;
+
+        // Use a simple unlit material so it's always visible
+        _lr.material = new Material(Shader.Find("Sprites/Default"));
+        SetColor(normalColor);
+        UpdateCorners();
+    }
+
+    void UpdateCorners()
+    {
+        float y = 0.05f; // slightly above ground to avoid z-fighting
+        _lr.SetPosition(0, new Vector3(xMin, y, zMin));
+        _lr.SetPosition(1, new Vector3(xMax, y, zMin));
+        _lr.SetPosition(2, new Vector3(xMax, y, zMax));
+        _lr.SetPosition(3, new Vector3(xMin, y, zMax));
+    }
+
+    void SetColor(Color c)
+    {
+        _lr.startColor = c;
+        _lr.endColor   = c;
+    }
+
+    /// Call from alert handler to flash the zone red.
+    public void OnAlert(bool active)
+    {
+        _alertActive = active;
+        SetColor(active ? alertColor : normalColor);
+    }
+
+    void OnGUI()
+    {
+        if (!showLabel) return;
+        // World-to-screen label at zone centre
+        Vector3 centre = new Vector3((xMin + xMax) / 2f, 0f, (zMin + zMax) / 2f);
+        Vector3 screen = Camera.main != null ? Camera.main.WorldToScreenPoint(centre) : Vector3.zero;
+        if (screen.z > 0)
+        {
+            GUI.color = _alertActive ? Color.red : new Color(1f, 0.5f, 0.5f);
+            GUI.Label(new Rect(screen.x - 80, Screen.height - screen.y - 10, 160, 20),
+                      "RESTRICTED ZONE");
+        }
+    }
+}

--- a/unity/Scripts/ZoneBoundary.cs
+++ b/unity/Scripts/ZoneBoundary.cs
@@ -39,8 +39,11 @@ public class ZoneBoundary : MonoBehaviour
         _lr.endWidth   = lineWidth;
         _lr.useWorldSpace = true;
 
-        // Use a simple unlit material so it's always visible
-        _lr.material = new Material(Shader.Find("Sprites/Default"));
+        // Use an unlit material — try URP first, fall back to Built-in
+        var shader = Shader.Find("Universal Render Pipeline/Unlit")
+                  ?? Shader.Find("Sprites/Default")
+                  ?? Shader.Find("Unlit/Color");
+        _lr.material = new Material(shader);
         SetColor(normalColor);
         UpdateCorners();
     }


### PR DESCRIPTION
Closes #45

## What's added

### `unity/Scripts/VesselPath.cs` (new)
- Vessel moves east at 2 m/s from x=0 to x=700, y=350
- Logs zone entry at x=300 (`RESTRICTED_ZONE_APPROACH` fires in clarus at this point)
- Loops with 5s pause — useful for repeated demo takes
- `OnDrawGizmos`: draws vessel path, zone rectangle, and zone entry line in Scene view

### `unity/Scripts/ZoneBoundary.cs` (new)
- `LineRenderer` rectangle matching `sg-maritime-security/rules.json` polygon (x∈[300,600], y∈[200,500])
- `normalColor` (dim red) → `alertColor` (bright red) via `OnAlert(bool)`
- `OnGUI` label "RESTRICTED ZONE" at zone centre

### `unity/README.md`
- Scripts table listing all 5 scripts
- Scene 2 full setup instructions (water plane, vessel, zone, top-down camera at y=600)
- `eds ingest stream` command for maritime profile
- 5-minute demo video script with timestamps

## How the pipeline works
```
Unity Play → ClarusUdpExporter → UDP:9000
  → eds ingest stream --profile sg-maritime-security
  → RESTRICTED_ZONE_APPROACH HIGH fires at x=300m
  → clarus UI shows alert + regulation citation (IPA Cap. 136A §18)
```

## Test plan
- [ ] VesselPath starts at (0, 0, 350) and reaches (700, 0, 350)
- [ ] Unity console logs zone entry at x≈300
- [ ] `eds ingest stream` prints `RESTRICTED_ZONE_APPROACH HIGH` at correct frame
- [ ] ZoneBoundary rectangle visible in Scene view Gizmos

🤖 Generated with [Claude Code](https://claude.com/claude-code)