### PR TITLE
docs: update demo-guide, personas, roadmap for Flow 1 + Flow 2 + audit MVP

### DIFF
--- a/docs/demo-guide.md
+++ b/docs/demo-guide.md
@@ -1,48 +1,135 @@
-# clarus — Interactive Demo Guide
+# clarus — Demo Guide
 
-How to run the full end-to-end pipeline on a development machine: no Unity licence required, no cloud API.
+Two independent demo paths depending on the audience:
+
+| Path | What it shows | URL |
+|---|---|---|
+| **Web demo** (CAP Vista / PIER71) | Flow 1 (live alerts) → Flow 2 (vessel scorecard) → audit chain | `clarus-analytics.pages.dev` |
+| **CLI demo** (technical deep-dive) | Rust rule engine, physics vs generic AI, LLM explanation | local terminal |
 
 ---
 
-## Prerequisites
+## Web Demo — CAP Vista / PIER71
+
+### Architecture
+
+```
+Edge daemon (local)
+  clarus/edge/   →  clarus-dev-public-raw     →  /live  Operations Monitor
+                 →  clarus-dev-public-audit   →  /audit (coming: #55)
+
+Synthetic data
+  generate_synthetic.py  →  clarus-dev-public-analytics  →  /  Risk Intelligence
+```
+
+### Prerequisites
+
+| Tool | Required for | Install |
+|---|---|---|
+| Rust / Cargo | Edge daemon | `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \| sh` |
+| wrangler | R2 uploads | `npm i -g wrangler && wrangler login` |
+| Python 3 + pandas + pyarrow | Synthetic data generation | `pip install pandas pyarrow numpy` |
+| llama.cpp + Caddy | LLM alert explanations (optional) | `brew install llama.cpp caddy` |
+
+### Step 1 — Start the edge daemon
+
+```bash
+cd clarus/edge
+./run.sh
+```
+
+`config.env` is loaded automatically. Key settings:
+
+```bash
+SITE_ID=site_sgp_001
+PROFILE=sg-maritime-security   # maritime scenario — generates V-001 vessel alerts
+STORAGE_BACKEND=wrangler       # uses existing wrangler login, no extra credentials
+HEARTBEAT_INTERVAL=30          # heartbeat upload every 30 s
+```
+
+The daemon runs a loop: generate CV frames → evaluate rules → sign AuditRecord → upload to R2.
+
+To persist the signing key across restarts (recommended for demo):
+
+```bash
+# Generate a key once and add to config.env
+cargo run -- --private-key-hex "" 2>&1 | grep PRIVATE_KEY_HEX
+# → WARN PRIVATE_KEY_HEX not set — generated ephemeral key. Set PRIVATE_KEY_HEX=<hex>
+echo "PRIVATE_KEY_HEX=<hex from above>" >> config.env
+```
+
+### Step 2 — Generate synthetic vessel data (Flow 2)
+
+```bash
+cd clarus/analytics
+source /path/to/.venv/bin/activate   # virtualenv with pandas + pyarrow
+python scripts/generate_synthetic.py
+```
+
+Generates 500 synthetic vessels including demo spotlight MV Fortune Star (MMSI 563012345) and uploads to `clarus-dev-public-analytics`.
+
+To regenerate live demo data (Flow 1):
+
+```bash
+python scripts/generate_live_demo.py
+```
+
+### Step 3 — Start local LLM (optional)
+
+Enables AI-generated alert explanations in `/live`.
+
+```bash
+cd clarus
+./scripts/run_llama.sh
+```
+
+Starts llama-server on `:8080` + Caddy HTTPS proxy on `:8443`. The analytics app calls `https://localhost:8443/v1/chat/completions`.
+
+### Step 4 — Open the web app
+
+| Page | URL | What to show |
+|---|---|---|
+| Operations Monitor | https://feat-analytics-scorecard.clarus-analytics.pages.dev/live | Flow 1 |
+| Risk Intelligence | https://feat-analytics-scorecard.clarus-analytics.pages.dev/ | Flow 2 |
+
+### Demo flow (5–7 min)
+
+**Flow 1 — Operations Monitor** (`/live`)
+
+1. **Site Status cards** — `site_sgp_001` with VALID / DEGRADED / UNCALIBRATED states
+2. **Calibration Drift chart** — periodic spikes when drift > 0.3 m (DEGRADED) or > 0.6 m (UNCALIBRATED)
+3. **Evidence Quality chart** — Rejected count rises when calibration degrades
+4. **Recent Alerts** — filter to `RESTRICTED_ZONE_APPROACH`, click a **Certified** row
+5. LLM explanation expands with evidence quality sentence injected deterministically
+6. Click **"View V-001 vessel risk profile →"**
+
+**Flow 2 — Risk Intelligence** (`/`)
+
+7. MV Fortune Star auto-selected (same vessel as V-001)
+8. Behavioral score **74.3 / 100**, HIGH RISK
+9. **Premium Impact** section:
+   - Traditional underwriting (flag/age/type only): **$180,000**
+   - EdgeSentry signals: AIS gaps 14 ⚠, STS 3 ⚠, Sanctions proximity 2 hops ⚠
+   - With EdgeSentry: **$340,000 (+89%)**
+10. Actuarial Data Availability table — Layer A (incident outcome data) is the remaining gap
+
+**Closing line**
+
+> "Flow 1 collects tamper-evident evidence from the edge. Flow 2 turns that evidence into actuarially justifiable premium pricing. EdgeSentry closes the underwriting blind spot."
+
+---
+
+## CLI Demo — Technical Deep-dive
+
+### Prerequisites
 
 | Tool | Required for | Install |
 |---|---|---|
 | Rust / Cargo | All stages | `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \| sh` |
 | Python 3 | Live UDP simulation | pre-installed on macOS |
-| Ollama | LLM explanation stage | `brew install ollama` |
-| llama3.2 model | LLM explanation stage | `ollama pull llama3.2` |
+| Ollama | LLM explanation stage | `brew install ollama && ollama pull llama3.2` |
 
-All stages except the LLM explanation work offline with no additional dependencies.
-
----
-
-## Quick start — automated test
-
-Run all five stages in one command from the repo root:
-
-```bash
-./scripts/test-e2e.sh
-```
-
-Skip stages you don't need:
-
-```bash
-./scripts/test-e2e.sh --no-explain          # skip Ollama (no LLM required)
-./scripts/test-e2e.sh --no-udp              # skip live UDP
-./scripts/test-e2e.sh --no-explain --no-udp # rule engine only
-./scripts/test-e2e.sh --model mistral       # use a different local model
-```
-
-The script exits 0 on success and prints a coloured pass/fail summary.
-
----
-
-## Stage-by-stage walkthrough
-
-### Stage 1 — Rule engine with CSV fixture (no Ollama)
-
-Replays `fixtures/forklift_approach.csv`: FL-01 (forklift at 1.4 m/s) closes on W-03 (stationary worker) over 15 frames. All computation is deterministic Rust — no LLM involved.
+### Stage 1 — Rule engine with CSV fixture
 
 ```bash
 cargo run --bin clarus -- \
@@ -50,164 +137,56 @@ cargo run --bin clarus -- \
   --profile profiles/demo
 ```
 
-Expected output (first and last frames):
+FL-01 (forklift) closes on W-03 (worker) over 15 frames. Expected output:
 
 ```
-Loaded 3 rules from profiles/demo/rules.json
-Replaying 15 frames from fixtures/forklift_approach.csv
-[t=1000ms] RISK High  rule=PROXIMITY_ALERT  entities=["FL-01","W-03"]  value=3.20  threshold=5.00  reg=Site Safety Procedure §3.1
-[t=1000ms] RISK High  rule=TTC_ALERT   entities=["FL-01","W-03"]  value=2.29  threshold=3.00  reg=Site Safety Procedure §3.1
+[t=1000ms] RISK High  rule=PROXIMITY_ALERT  value=3.20  threshold=5.00
+[t=1000ms] RISK High  rule=TTC_ALERT        value=2.29  threshold=3.00
 ...
-[t=2400ms] RISK High  rule=TTC_ALERT   entities=["FL-01","W-03"]  value=0.89  threshold=3.00  ...
-Replay complete.
+[t=2400ms] RISK High  rule=TTC_ALERT        value=0.89  threshold=3.00
 ```
 
-What to look for:
-- `PROXIMITY_ALERT` fires every frame (distance stays below 5 m throughout)
-- `TTC_ALERT` fires with decreasing value (2.29 s → 0.89 s) as FL-01 closes in
-- `EXCLUSION_ZONE_BREACH` fires because both entities start inside the seed zone polygon
-
----
-
-### Stage 2 — Rule engine with LLM explanation
-
-Requires Ollama running locally. Start it first:
+### Stage 2 — LLM explanation
 
 ```bash
-ollama serve          # starts the Ollama daemon (separate terminal or background)
-ollama pull llama3.2  # one-time download ~2 GB
-```
-
-Then run clarus with the `--explain` flag:
-
-```bash
+ollama serve
 cargo run --bin clarus -- \
   --input file://fixtures/forklift_approach.csv \
   --profile profiles/demo \
   --explain
 ```
 
-Each RiskEvent now gets a plain-language explanation line:
+Each event gets a grounded plain-language explanation. `✓` = regulation clause verified against KB. `⚠ ungrounded` = LLM hallucinated a clause.
 
-```
-[t=1000ms] RISK High  rule=PROXIMITY_ALERT  entities=["FL-01","W-03"]  value=3.20  threshold=5.00  ...
-  [EXPLANATION ✓] Forklift FL-01 is 3.20 m from worker W-03, which is below the 5-metre minimum
-  clearance required by Site Safety Procedure §3.1. The vehicle operator must
-  stop immediately or a banksman must be appointed before movement resumes.
-```
+### Stage 3 — Live UDP
 
-The `✓` means the explanation is grounded — every regulation clause it cites (`§3.1`) was present in the retrieved KB snippet. An `⚠ ungrounded` marker means the LLM hallucinated a clause; that response is flagged but still printed so the operator can see it.
-
-**Model options:**
-
+**Terminal 1:**
 ```bash
-# Use Mistral instead of Llama 3.2
-cargo run --bin clarus -- \
-  --input file://fixtures/forklift_approach.csv \
-  --profile profiles/demo \
-  --explain \
-  --model mistral
-
-# Point to Ollama on another machine
-cargo run --bin clarus -- \
-  --input file://fixtures/forklift_approach.csv \
-  --profile profiles/demo \
-  --explain \
-  --ollama-url http://192.168.1.10:11434
+cargo run --bin clarus -- --input udp://127.0.0.1:9000 --profile profiles/demo
 ```
 
----
-
-### Stage 3 — Live UDP (two terminals)
-
-Simulates Unity sending entity data in real time. Open two terminal windows in the repo root.
-
-**Terminal 1 — start the listener:**
-
+**Terminal 2:**
 ```bash
-cargo run --bin clarus -- \
-  --input udp://127.0.0.1:9000 \
-  --profile profiles/demo
+python3 scripts/sim-unity-udp.py                   # forklift approach
+python3 scripts/sim-unity-udp.py --scenario safe   # safe pass — no alerts
 ```
 
-Output: `Listening on udp://127.0.0.1:9000 …`  (blocks, waiting for packets)
+### Simulator scenarios
 
-**Terminal 2 — send packets:**
-
-```bash
-# Default: forklift approach scenario, 15 frames at 10 Hz
-python3 scripts/sim-unity-udp.py
-
-# Zone breach scenario
-python3 scripts/sim-unity-udp.py --scenario exclusion
-
-# Safe pass — no rules should fire
-python3 scripts/sim-unity-udp.py --scenario safe
-
-# Custom parameters
-python3 scripts/sim-unity-udp.py --addr 127.0.0.1:9000 --count 30 --interval 0.1
-```
-
-Simulator output:
-
-```
-Sending 15 'approach' frames to udp://127.0.0.1:9000 at 10 Hz …
-  [  1/15] t=1000ms  2 entities  134 bytes
-  [  2/15] t=1100ms  2 entities  136 bytes
-  ...
-Done.
-```
-
-Terminal 1 will print RiskEvents in real time as each packet arrives.
-
-**With explanation (requires Ollama):**
-
-```bash
-# Terminal 1
-cargo run --bin clarus -- \
-  --input udp://127.0.0.1:9000 \
-  --profile profiles/demo \
-  --explain
-
-# Terminal 2
-python3 scripts/sim-unity-udp.py --interval 0.5  # slower, easier to read
-```
-
----
-
-## Simulator scenarios
-
-| Scenario | Command | Rules expected to fire |
-|---|---|---|
-| `approach` | `--scenario approach` | `PROXIMITY_ALERT`, `TTC_ALERT` |
-| `exclusion` | `--scenario exclusion` | `EXCLUSION_ZONE_BREACH` |
-| `safe` | `--scenario safe` | none |
-
----
-
-## Profile structure
-
-The `--profile` flag points to a directory containing:
-
-```
-profiles/demo/
-  rules.json        ← rule definitions (condition, severity, regulation citation)
-  kb/
-    PROXIMITY_ALERT.txt      ← regulation text retrieved for LLM prompt
-    TTC_ALERT.txt
-    EXCLUSION_ZONE_BREACH.txt
-```
-
-To test a different rule set, create a new profile directory with its own `rules.json` and `kb/` files and pass `--profile profiles/<your-profile>`.
+| Scenario | Rules expected |
+|---|---|
+| `approach` (default) | `PROXIMITY_ALERT`, `TTC_ALERT` |
+| `exclusion` | `EXCLUSION_ZONE_BREACH` |
+| `safe` | none |
 
 ---
 
 ## Troubleshooting
 
-| Symptom | Likely cause | Fix |
+| Symptom | Cause | Fix |
 |---|---|---|
-| `Cannot bind UDP socket` | Port already in use | Change port: `--input udp://127.0.0.1:9001` and `--addr 127.0.0.1:9001` |
-| `[EXPLANATION ERROR] Ollama request failed` | Ollama not running | `ollama serve` in a separate terminal |
-| `Model 'llama3.2' not found` | Model not pulled | `ollama pull llama3.2` |
-| No events printed during UDP test | Packets sent before listener ready | Wait for `Listening on udp://…` before sending |
-| `Cannot read profiles/demo/rules.json` | Run from wrong directory | Run commands from repo root, not from `crates/` |
+| `/live` shows "No live data yet" | Edge daemon not running or no data uploaded | Run `./edge/run.sh` and wait 30 s |
+| LLM explanation shows "LLM offline" | llama.cpp not running | `./scripts/run_llama.sh` |
+| R2 upload failed | wrangler not logged in | `wrangler login` |
+| `clarus-dev-public-audit` upload fails | Object Lock — delete attempted | Object Lock is working correctly; writes still succeed |
+| Port 8443 already in use | Previous Caddy instance | `pkill caddy && ./scripts/run_llama.sh` |

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -21,18 +21,18 @@ Last year a near-miss incident occurred. MOM requested a report. Kenny stated th
 
 > "The next time MOM arrives, I want to produce a tamper-proof record — timestamped by a third party, sealed against editing — showing exactly what monitoring was active, in which zone, during which shift, and what violations were recorded."
 
-### How Kenny uses the demo app
+### How Kenny uses the demo
 
-1. **Presses Run Demo** — the forklift-approaches-worker scenario plays back
-2. Sees the left panel fire 4 alerts on a safe pass — recognises "this is the problem with what I have now"
-3. Sees the right panel stay silent until the real danger moment — "this is what I need"
-4. Clicks the HIGH event — reads `"Forklift FL-01 is 3.2m from Worker W-03 — below the 5m minimum required under MPA Port Safety Circular 2024-07 §3.1. Braking distance 4.1m exceeds remaining gap. Collision window: 2.3 seconds."`
-5. **Presses Generate MOM Report** — PDF opens automatically
-6. Reads the PDF: timestamp, regulation citation, measured value, threshold — all present
+1. Opens `/live` Operations Monitor — sees site status VALID, calibration drift stable
+2. Sees a `RESTRICTED_ZONE_APPROACH HIGH` alert fire in real time
+3. Clicks the alert — reads the AI-generated explanation with regulation citation
+4. Sees `Evidence quality: CERTIFIED (CV confidence 0.92) — this record carries full evidential weight and is admissible in insurance claims`
+5. *(coming: #55)* Opens `/audit` — sees "Chain intact — N records, 0 gaps ✅"
+6. Understands: "these records are in WORM storage — Object Lock means I cannot delete them even if I wanted to"
 
 ### The moment his goal is achieved
 
-> "I can hand this to MOM. The timestamp is in the PDF. The regulation clause is cited. The measured values are there. And I didn't write any of it — the system generated and signed it automatically. This is evidence I didn't produce myself."
+> "I can hand this to MOM. The timestamp is in the record. The regulation clause is cited. The measured values are there. And I didn't write any of it — the system generated and signed it automatically. This is evidence I didn't produce myself."
 
 ---
 
@@ -53,13 +53,16 @@ Singapore's MOM WSH penalties have tightened. P&I claims after serious incidents
 
 > "I want to see how many near-misses this terminal actually generates, in a time series. If I have two years of data showing their rate is below the industry average, I have a defensible basis for a premium reduction. Right now I'm pricing on guesswork."
 
-### How Sarah uses the demo app
+### How Sarah uses the demo
 
-1. **Presses Run Demo** — watches the right panel event feed
-2. Reads the structured data on each event: `rule_id: PROXIMITY_ALERT, severity: HIGH, measured_value: 3.2, threshold: 5.0, regulation: MPA §3.1`
-3. Understands: "if this accumulates monthly across a site, I can calculate a near-miss frequency and compare it against my book"
-4. **Opens the Verify Audit Chain tab** — pastes an AuditRecord JSON, presses Verify
-5. Sees `"✓ Chain valid — 7 records, no tampering detected"` — understands the data cannot be edited by the operator
+1. Opens `/live` — watches alert table showing rule, severity, evidence quality, confidence score
+2. Understands: "if this accumulates monthly, I can calculate a near-miss frequency"
+3. Clicks `RESTRICTED_ZONE_APPROACH` alert → sees "View V-001 vessel risk profile →"
+4. Navigates to `/` Risk Intelligence — MV Fortune Star auto-selected
+5. Reads behavioral score 74.3/100, sees AIS gaps, STS transfers, sanctions proximity
+6. **Premium Impact section**: Traditional $180,000 → With EdgeSentry $340,000 (+89%)
+7. Sees "Blind spot" in the traditional column for all behavioral signals
+8. Understands: "the $160k gap is exactly what I'm missing in my current underwriting"
 
 ### The moment her goal is achieved
 
@@ -84,13 +87,14 @@ David's reaction to "new AI safety system" is reflexive scepticism. He has heard
 
 > "I need a system that operators won't ignore. If there are no false alarms, the real alert gets attention. That's the entire requirement."
 
-### How David uses the demo app
+### How David uses the demo
 
-1. **Presses Run Demo** — sees the left panel fire 4 times on the same safe pass and grimaces: "that's what I have"
-2. Watches the right panel: silent, silent, silent — then 🚨 STOP. Leans forward.
-3. Clicks the HIGH event — reads `"braking distance 4.1m exceeds remaining gap 3.2m — collision window: 2.3 seconds"`
-4. Realises: "this is physics, not pattern-matching. The system is asking 'can this forklift stop in time?' not 'are these two objects close?'"
-5. Compares 4 false alarms on the left to 1 correct alert on the right — "operators will respond to this"
+1. Opens `/live` — filters alerts to `PROXIMITY_ALERT`
+2. Sees that alerts fire only when `confidence_cv` is high and calibration is VALID
+3. Expands an alert — reads "braking distance 4.1m exceeds remaining gap 3.2m — collision window: 2.3 seconds"
+4. Understands: "this is physics, not pattern-matching — false alarms on a safe pass are physically impossible"
+5. Checks the Evidence Quality chart — Certified (green) dominates; Rejected only during calibration degradation
+6. Concludes: "operators will respond to this because it will never cry wolf"
 
 ### The moment his goal is achieved
 
@@ -115,13 +119,13 @@ In most cases the operator asserts the system was active. The only evidence avai
 
 > "I need to verify that safety monitoring was active at the time of the incident — not from a record the operator controls, but from a record held by an independent third party that the operator cannot modify."
 
-### How James uses the demo app
+### How James uses the demo
 
-1. Receives an AuditRecord JSON from the operator
-2. **Opens the Verify Audit Chain tab** — pastes the JSON, presses Verify Chain
-3. Reads `"✓ Chain valid — 7 records, no tampering detected"`
-4. Inspects individual records: `timestamp_ms`, `rule_id`, `severity`, `prev_record_hash`
-5. Confirms the chain is continuous and each `prev_record_hash` links correctly to the previous record
+1. *(coming: #55)* Opens `/audit` — sees records listed in sequence order
+2. Reads "Chain intact — N records, 0 gaps ✅ — Object Lock: deletion not possible"
+3. Clicks a record — sees `timestamp_ms`, `rule_id`, `severity`, `prev_hash`, `signature`
+4. Understands: prev_hash linkage means any deletion or modification is detectable
+5. Confirms: "the operator cannot edit this chain — it is in WORM storage and the hash chain is independently verifiable"
 
 ### The moment his goal is achieved
 
@@ -129,14 +133,16 @@ In most cases the operator asserts the system was active. The only evidence avai
 
 ---
 
-## Demo app feature × persona matrix
+## Demo feature × persona matrix
 
 | Feature | Kenny (Safety Manager) | Sarah (Underwriter) | David (Ops Manager) | James (MOM Inspector) |
 |---|---|---|---|---|
-| Run Demo — split-screen | ✓ Recognises false alarm problem | ✓ Sees data structure | ✓ Confirms zero false alarms | — |
-| Event Detail — explanation | ✓ Reads regulation citation | ✓ Reads structured fields | ✓ Understands physics basis | — |
-| Generate MOM Report | ✓ **Core feature** | ✓ Sees monthly report format | — | ✓ Sees record format |
-| Verify Audit Chain | ✓ Understands tamper-evidence | ✓ Confirms operator cannot edit | — | ✓ **Core feature** |
+| `/live` site status + drift chart | ✓ Sees monitoring is active | — | ✓ Sees calibration quality | — |
+| `/live` alert table with evidence quality | ✓ Reads regulation citation | ✓ Sees structured data fields | ✓ Confirms physics-based firing | — |
+| `/live` LLM explanation | ✓ Reads plain-language alert | — | ✓ Understands physics basis | — |
+| `/` vessel risk scorecard | — | ✓ Sees behavioral indicators | — | — |
+| `/` premium impact (Blind spot → $340k) | — | ✓ **Core feature** | — | — |
+| `/audit` chain verification *(coming: #55)* | ✓ Understands tamper-evidence | ✓ Confirms operator cannot edit | — | ✓ **Core feature** |
 
 ---
 

--- a/docs/roadmap1-poc.md
+++ b/docs/roadmap1-poc.md
@@ -160,24 +160,26 @@ Goal: `RiskEvent` → natural-language explanation with verifiable regulation ci
 
 ### Week 5: Browser demo (due: 1 June)
 
-Goal: end-to-end screen-recordable demo showing the split-screen comparison and the full pipeline.
+Goal: end-to-end screen-recordable demo showing Flow 1 (live alerts) → Flow 2 (vessel risk scorecard).
 
-**Tasks:**
+**Implemented** ([PR #52](https://github.com/edgesentry/clarus/pull/52), merged 2026-05-02):
 
-- [ ] `ui/` — minimal browser app (Axum or similar, or just a static HTML file served locally):
-  - Split-screen view:
-    - Left panel: "Generic proximity AI" mode — alert fires at every entity pair within 8 m (raw geometry, no physics)
-    - Right panel: clarus mode — alert fires only when `braking_distance > remaining_distance`
-  - Right panel event feed: click event → show explanation + regulation citation
-  - "Generate MOM Report" button → export PDF containing:
-    - Event timestamp, entities, measured value vs threshold
-    - Exact regulation clause
-    - `edgesentry-audit` hash and signature
-    - Section heading: "Monitoring system: active and enforcing correct standard at time of event"
-- [ ] `ui/verify.html` — paste AuditRecord JSON → show verification result (green/red)
-- [ ] Record 5-min demo video:
-  1. (0:00–0:30) Unity scene running, forklift approaching pedestrian
-  2. (0:30–2:30) Split-screen: left fires 4 alerts on a safe pass, right fires 0; then forklift accelerates, right fires 1 alert at the correct TTC
+- [x] `analytics/` — Cloudflare Pages app (DuckDB WASM + Observable Plot, no build step)
+- [x] `/live` Operations Monitor — site status, calibration drift chart, evidence quality chart, alert table with filters
+- [x] `/live` LLM explanation — llama.cpp via Caddy HTTPS proxy; evidence quality sentence injected deterministically by JS; OPFS-backed cache
+- [x] `/` Risk Intelligence — 500-vessel fleet overview + per-vessel behavioral scorecard
+- [x] `/` Premium Impact — Traditional baseline ($180k) → EdgeSentry signals → $340k (+89%)
+- [x] Flow 1→2 link — V-001 alert links to MV Fortune Star MMSI 563012345
+- [x] `edge/` — Rust edge daemon (CV sim → evaluate → sign → R2 upload) ([#54](https://github.com/edgesentry/clarus/issues/54))
+- [x] R2 infrastructure — `clarus-dev-public-raw`, `clarus-dev-public-analytics`, `clarus-dev-public-audit` (Object Lock) + naming convention documented
+- [x] `scripts/run_llama.sh` — llama-server + Caddy HTTPS proxy setup
+
+**Remaining:**
+
+- [ ] `/audit` chain verification page — sequence continuity check + hash chain visual (#55)
+- [ ] Record 5-min demo video (Flow 1 → Flow 2, CAP Vista scenario)
+
+**Deployed at:** https://feat-analytics-scorecard.clarus-analytics.pages.dev
   3. (2:30–4:00) Click the event → explanation appears → regulation citation shown
   4. (4:00–5:00) Click "Generate MOM Report" → PDF opens → run `verify` → green checkmark
 

--- a/edge/config.env.example
+++ b/edge/config.env.example
@@ -20,9 +20,14 @@ R2_SECRET_ACCESS_KEY=
 
 # ── Buckets ───────────────────────────────────────────────────────────────────
 # RAW_BUCKET:   device output — heartbeats + alerts → /live Operations Monitor
-# AUDIT_BUCKET: signed AuditRecord chain — private, disaster recovery
+# AUDIT_BUCKET: signed AuditRecord chain (PoC: public + Object Lock; production: private + Object Lock Compliance)
 RAW_BUCKET=clarus-dev-public-raw
-AUDIT_BUCKET=clarus-dev-private-audit
+AUDIT_BUCKET=clarus-dev-public-audit
+
+# ── Signing key (optional) ─────────────────────────────────────────────────────
+# Leave empty to generate an ephemeral key on each start (fine for local dev).
+# For demo: generate once with `./run.sh` and copy the PRIVATE_KEY_HEX from the log.
+# PRIVATE_KEY_HEX=
 
 # ── Paths ─────────────────────────────────────────────────────────────────────
 EDS_BIN=../../edgesentry-rs/target/debug/eds


### PR DESCRIPTION
## Summary

- `docs/demo-guide.md`: web demo (Cloudflare Pages) を主軸に全面書き直し。Edge daemon 起動手順・LLM セットアップ・5-7分デモフロー（Flow 1 → Flow 2）を追加。CLI デモは技術深掘り用として残存
- `docs/personas.md`: `/live` と `/` の実装に合わせてデモ手順を更新。`/audit` は coming (#55) として明記。Feature × persona matrix 更新
- `docs/roadmap1-poc.md`: Week 5 タスクを完了扱いに更新（PR #52）。残作業 `/audit` ページ (#55) とデモ動画を記載
- `edge/config.env.example`: `AUDIT_BUCKET` を `clarus-dev-public-audit` に修正。`PRIVATE_KEY_HEX` コメント追加

## Checklist

- [x] `config.env` は `.gitignore` 済み（secrets を含む可能性）→ `config.env.example` のみコミット
- [x] `/audit` ページ未実装部分は `*(coming: #55)*` として明記

🤖 Generated with [Claude Code](https://claude.com/claude-code)