### PR TITLE
feat(edge): migrate sim to SensorReading::simulation()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,17 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-      - name: Checkout edgesentry-rs
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-        with:
-          repository: edgesentry/edgesentry-rs
-          path: edgesentry-rs
+      - name: Checkout edgesentry-rs (matching branch or main)
+        run: |
+          BRANCH="${{ github.head_ref || github.ref_name }}"
+          if git clone --branch "$BRANCH" --depth 1 \
+              https://github.com/edgesentry/edgesentry-rs.git edgesentry-rs 2>/dev/null; then
+            echo "edgesentry-rs: checked out $BRANCH"
+          else
+            git clone --depth 1 \
+              https://github.com/edgesentry/edgesentry-rs.git edgesentry-rs
+            echo "edgesentry-rs: fell back to default branch"
+          fi
 
       - name: Setup Rust
         run: rustup update stable && rustup default stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,17 +32,11 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-      - name: Checkout edgesentry-rs (matching branch or main)
-        run: |
-          BRANCH="${{ github.head_ref || github.ref_name }}"
-          if git clone --branch "$BRANCH" --depth 1 \
-              https://github.com/edgesentry/edgesentry-rs.git edgesentry-rs 2>/dev/null; then
-            echo "edgesentry-rs: checked out $BRANCH"
-          else
-            git clone --depth 1 \
-              https://github.com/edgesentry/edgesentry-rs.git edgesentry-rs
-            echo "edgesentry-rs: fell back to default branch"
-          fi
+      - name: Checkout edgesentry-rs
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          repository: edgesentry/edgesentry-rs
+          path: edgesentry-rs
 
       - name: Setup Rust
         run: rustup update stable && rustup default stable

--- a/edge/src/main.rs
+++ b/edge/src/main.rs
@@ -214,9 +214,10 @@ fn calibration_status(drift: f32) -> &'static str {
 
 fn quality_counts(events: &[RiskEvent]) -> (u32, u32, u32) {
     events.iter().fold((0, 0, 0), |(c, d, r), e| match e.evidence_quality {
-        EvidenceQuality::Certified => (c + 1, d, r),
-        EvidenceQuality::Degraded  => (c, d + 1, r),
-        EvidenceQuality::Rejected  => (c, d, r + 1),
+        EvidenceQuality::Certified     => (c + 1, d, r),
+        EvidenceQuality::Degraded      => (c, d + 1, r),
+        EvidenceQuality::Rejected      => (c, d, r + 1),
+        EvidenceQuality::NotApplicable => (c, d, r),
     })
 }
 

--- a/edge/src/sim.rs
+++ b/edge/src/sim.rs
@@ -2,7 +2,7 @@
 ///
 /// Confidence values are deterministic functions of (cycle, frame, entity_index)
 /// so the demo is reproducible without randomness.
-use edgesentry_types::{Entity, EntityClass, Vec2};
+use edgesentry_types::{Entity, EntityClass, SensorReading, Vec2};
 
 #[derive(Debug, Clone)]
 pub struct Frame {
@@ -63,9 +63,6 @@ fn port_safety_frame(cycle: u64, frame: u64, timestamp_ms: u64) -> Frame {
     let raw = 12.0 - ((cycle * 10 + frame) % 15) as f32 * step * 0.8;
     let fl_x = raw.max(0.5);
 
-    let fl_conf = confidence(cycle, frame, 0);
-    let w_conf  = confidence(cycle, frame, 1);
-
     Frame {
         timestamp_ms,
         entities: vec![
@@ -75,7 +72,7 @@ fn port_safety_frame(cycle: u64, frame: u64, timestamp_ms: u64) -> Frame {
                 position: Vec2::new(fl_x, 0.0),
                 velocity: Vec2::new(-step * 0.8, 0.0),
                 timestamp_ms,
-                confidence: Some(fl_conf),
+                sensor: Some(SensorReading::simulation()),
             },
             Entity {
                 id: "W-03".into(),
@@ -83,7 +80,7 @@ fn port_safety_frame(cycle: u64, frame: u64, timestamp_ms: u64) -> Frame {
                 position: Vec2::new(12.0, 0.0),
                 velocity: Vec2::new(0.0, 0.0),
                 timestamp_ms,
-                confidence: Some(w_conf),
+                sensor: Some(SensorReading::simulation()),
             },
         ],
     }
@@ -94,7 +91,6 @@ fn port_safety_frame(cycle: u64, frame: u64, timestamp_ms: u64) -> Frame {
 fn maritime_frame(cycle: u64, frame: u64, timestamp_ms: u64) -> Frame {
     // Vessel x: 0 → 700, loops every 35 cycles × 10 frames = 350 frames
     let pos = ((cycle * 10 + frame) % 350) as f32 * 2.0;
-    let conf = confidence(cycle, frame, 0);
 
     Frame {
         timestamp_ms,
@@ -105,28 +101,12 @@ fn maritime_frame(cycle: u64, frame: u64, timestamp_ms: u64) -> Frame {
                 position: Vec2::new(pos, 350.0),
                 velocity: Vec2::new(2.0, 0.0),
                 timestamp_ms,
-                confidence: Some(conf),
+                sensor: Some(SensorReading::simulation()),
             },
         ],
     }
 }
 
-// ── Confidence ────────────────────────────────────────────────────────────────
-
-/// Deterministic confidence for (cycle, frame, entity_index).
-///
-/// Every 5th cycle, frames 3–4 of entity 0 → REJECTED  (0.28–0.42)
-/// Every 3rd cycle, frame  7  of entity 0 → DEGRADED   (0.55–0.74)
-/// Otherwise                              → CERTIFIED   (0.88–0.99)
-fn confidence(cycle: u64, frame: u64, entity: u64) -> f32 {
-    if cycle % 5 == 0 && (frame == 3 || frame == 4) && entity == 0 {
-        0.28 + ((cycle * 7 + frame) % 15) as f32 * 0.01
-    } else if cycle % 3 == 0 && frame == 7 && entity == 0 {
-        0.55 + ((cycle * 3 + frame) % 20) as f32 * 0.01
-    } else {
-        0.88 + ((cycle * 11 + frame * 7 + entity * 3) % 12) as f32 * 0.01
-    }
-}
 
 #[cfg(test)]
 mod tests {
@@ -144,15 +124,6 @@ mod tests {
         let frames = generate_frames(&Scenario::Maritime, 0, 0);
         assert_eq!(frames.len(), 10);
         assert_eq!(frames[0].entities[0].id, "V-001");
-    }
-
-    #[test]
-    fn confidence_cycle5_frames_3_4_are_rejected() {
-        // cycle=5, frame=3, entity=0 → < 0.5 → REJECTED
-        assert!(confidence(5, 3, 0) < 0.5);
-        assert!(confidence(5, 4, 0) < 0.5);
-        // entity 1 unaffected
-        assert!(confidence(5, 3, 1) >= 0.8);
     }
 
     #[test]

--- a/edge/src/sim.rs
+++ b/edge/src/sim.rs
@@ -73,6 +73,7 @@ fn port_safety_frame(cycle: u64, frame: u64, timestamp_ms: u64) -> Frame {
                 velocity: Vec2::new(-step * 0.8, 0.0),
                 timestamp_ms,
                 sensor: Some(SensorReading::simulation()),
+                position_z: None, velocity_z: None, computed_confidence: None,
             },
             Entity {
                 id: "W-03".into(),
@@ -81,6 +82,7 @@ fn port_safety_frame(cycle: u64, frame: u64, timestamp_ms: u64) -> Frame {
                 velocity: Vec2::new(0.0, 0.0),
                 timestamp_ms,
                 sensor: Some(SensorReading::simulation()),
+                position_z: None, velocity_z: None, computed_confidence: None,
             },
         ],
     }
@@ -102,6 +104,7 @@ fn maritime_frame(cycle: u64, frame: u64, timestamp_ms: u64) -> Frame {
                 velocity: Vec2::new(2.0, 0.0),
                 timestamp_ms,
                 sensor: Some(SensorReading::simulation()),
+                position_z: None, velocity_z: None, computed_confidence: None,
             },
         ],
     }

--- a/scripts/test-e2e.sh
+++ b/scripts/test-e2e.sh
@@ -73,7 +73,10 @@ lines = [l for l in open('$TMP/events.jsonl') if l.strip() and not l.startswith(
 rules = {json.loads(l)['rule_id'] for l in lines}
 assert 'PROXIMITY_ALERT' in rules, 'PROXIMITY_ALERT missing'
 assert 'TTC_ALERT' in rules, 'TTC_ALERT missing'
-" && pass "PROXIMITY_ALERT and TTC_ALERT both fired" || fail "Expected risk events did not fire"
+# CSV replay uses SourceType::Simulation → EvidenceQuality::NotApplicable for all events
+qualities = {json.loads(l).get('evidence_quality') for l in lines}
+assert qualities == {'NOT_APPLICABLE'}, f'expected all NOT_APPLICABLE (simulation source), got {qualities}'
+" && pass "PROXIMITY_ALERT and TTC_ALERT fired; evidence_quality=NOT_APPLICABLE (simulation source)" || fail "Expected risk events or evidence quality check failed"
 pause
 
 header "Stage 3 — Assess (RiskEvent → Assessment JSONL)"


### PR DESCRIPTION
## Summary

- Sim entities now carry `SourceType::Simulation` via `SensorReading::simulation()` instead of a bare confidence score
- Removes the `confidence()` deterministic function (no longer needed — sim data uses NotApplicable quality)
- `quality_counts()` and `build_audit_envelope()` handle `EvidenceQuality::NotApplicable`

Depends on: edgesentry/edgesentry-rs#349

## Test plan

- [ ] `cargo test` — all 10 edge tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)