### PR TITLE
chore: rename Pages project clarus-analytics → clarus

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -1,0 +1,32 @@
+name: Deploy to Cloudflare Pages
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "analytics/**"
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Deploy clarus → clarus.pages.dev
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Deploy to Cloudflare Pages
+        working-directory: analytics
+        run: |
+          COMMIT_MSG=$(git log -1 --pretty=format:'%s' | LC_ALL=C tr -cd '[:print:]' | cut -c1-72)
+          npx wrangler pages deploy . \
+            --project-name=clarus \
+            --branch=main \
+            --commit-dirty=true \
+            --commit-message="${COMMIT_MSG}"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/analytics/wrangler.toml
+++ b/analytics/wrangler.toml
@@ -1,4 +1,4 @@
-name = "clarus-analytics"
+name = "clarus"
 compatibility_date = "2026-05-02"
 pages_build_output_dir = "."
 


### PR DESCRIPTION
Updates wrangler.toml name from `clarus-analytics` to `clarus`.

Deployed to:
- https://clarus.pages.dev
- https://clarus.edgesentry.io

The old `clarus-analytics` project can be deleted from the Cloudflare dashboard once this is merged.