### PR TITLE
fix(ci): copy functions/ into dist/ — --functions-directory removed in wrangler 4.87.0

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -38,7 +38,9 @@ jobs:
 
       - name: Build
         working-directory: analytics
-        run: npm run build
+        run: |
+          npm run build
+          cp -r functions dist/functions
 
       - name: Deploy to Cloudflare Pages
         working-directory: analytics
@@ -48,8 +50,7 @@ jobs:
             --project-name=clarus \
             --branch=main \
             --commit-dirty=true \
-            --commit-message="${COMMIT_MSG}" \
-            --functions-directory functions
+            --commit-message="${COMMIT_MSG}"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Problem

`wrangler pages deploy` in 4.87.0 dropped the `--functions-directory` flag, causing CI to fail with `Unknown arguments: functions-directory`.

## Fix

Copy `functions/` into `dist/` as part of the build step. Cloudflare Pages auto-detects `functions/` when it exists inside the deploy directory.

```yaml
- name: Build
  run: |
    npm run build
    cp -r functions dist/functions
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)