### PR TITLE
fix(clarus): add documaris cross-link to analysis/ page (the page users actually see)

### DIFF
--- a/analytics/analysis/app.js
+++ b/analytics/analysis/app.js
@@ -3,6 +3,7 @@
 
 import * as duckdb from "https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@1.29.0/+esm";
 import * as Plot from "https://cdn.jsdelivr.net/npm/@observablehq/plot@0.6/+esm";
+import { updateDocumarisLink } from "../documaris-link.js";
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
@@ -157,6 +158,7 @@ async function selectVessel(conn, mmsi) {
 
   document.getElementById("sc-title").childNodes[0].textContent = v.vessel_name + " ";
   document.getElementById("sc-mmsi").textContent = `MMSI ${v.mmsi}`;
+  updateDocumarisLink(v.mmsi);
   document.getElementById("sc-score").textContent = score.toFixed(1);
   document.getElementById("sc-tier").textContent = tier === "high" ? "HIGH RISK" : tier === "medium" ? "MEDIUM RISK" : "LOW RISK";
   const scoreBox = document.getElementById("sc-score-box");

--- a/analytics/analysis/index.html
+++ b/analytics/analysis/index.html
@@ -67,6 +67,8 @@
     .card { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 20px; }
     .card h3 { font-size: 15px; font-weight: 600; margin-bottom: 16px; display: flex; align-items: center; gap: 8px; }
     .card h3 .mmsi { font-size: 12px; color: var(--muted); font-weight: 400; font-family: monospace; }
+    .documaris-link { margin-left: auto; font-size: 12px; color: var(--accent); text-decoration: none; padding: 4px 10px; border: 1px solid var(--accent); border-radius: 5px; white-space: nowrap; font-weight: 400; }
+    .documaris-link:hover { background: rgba(88,166,255,0.1); }
 
     /* Score header */
     .score-header { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 16px; margin-bottom: 20px; }
@@ -194,7 +196,7 @@
       <div id="scorecard">
         <!-- Score header -->
         <div class="card">
-          <h3 id="sc-title">—<span class="mmsi" id="sc-mmsi"></span></h3>
+          <h3 id="sc-title">—<span class="mmsi" id="sc-mmsi"></span><a id="sc-documaris-link" class="documaris-link" href="#" target="_blank" rel="noopener noreferrer" style="display:none">View port call documents in documaris →</a></h3>
           <div class="score-header">
             <div class="score-box" id="sc-score-box">
               <div class="label">Behavioral Risk Score</div>


### PR DESCRIPTION
## Root cause

`_redirects` sends `/ → /analysis/ 301`, so all users land on `analysis/index.html` + `analysis/app.js`. The cross-link was only wired into `app.ts` (the root `index.html`) which nobody sees.

## Fix

- `analysis/index.html` — adds `sc-documaris-link` anchor + `.documaris-link` CSS
- `analysis/app.js` — imports `updateDocumarisLink` from `../documaris-link.js` and calls it in `selectVessel()`

## Test plan

- [ ] Open `https://clarus-d5d.pages.dev` → redirects to `/analysis/`
- [ ] Select a vessel → "View port call documents in documaris →" appears in scorecard header
- [ ] Click link → documaris opens on that vessel directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)