### PR TITLE
feat(clarus): migrate analysis/app.js, audit.js, live.js to TypeScript

### DIFF
--- a/analytics/analysis/app.ts
+++ b/analytics/analysis/app.ts
@@ -1,37 +1,74 @@
-// EdgeSentry Vessel Risk Intelligence — app.js
-// DuckDB WASM + Observable Plot, no build step required.
+// EdgeSentry Vessel Risk Intelligence — analysis/app.ts
 
-import * as duckdb from "https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@1.29.0/+esm";
-import * as Plot from "https://cdn.jsdelivr.net/npm/@observablehq/plot@0.6/+esm";
+import * as duckdb from "@duckdb/duckdb-wasm";
+import * as Plot from "@observablehq/plot";
 import { updateDocumarisLink } from "../documaris-link.js";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface VesselRow {
+  mmsi: string;
+  vessel_name: string;
+  flag_state: string;
+  vessel_type: string;
+  built_year: number;
+  behavioral_score: number;
+  tier: "high" | "medium" | "low";
+  ais_gap_count_30d: number;
+  ais_gap_max_hours: number;
+  sts_candidate_count: number;
+  loitering_hours_30d: number;
+  sanctions_distance: number;
+  cluster_sanctions_ratio: number;
+  flag_changes_2y: number;
+  ownership_depth: number;
+  sanctions_list_count: number;
+  traditional_premium_usd: number;
+  behavioral_premium_usd: number;
+}
+
+type RiskLevel = "high" | "med" | "ok";
+
+interface Indicator {
+  key: string;
+  label: string;
+  max: number;
+  fmt: (v: number) => string;
+  risk: string;
+  invert?: boolean;
+}
+
+interface Signal {
+  key: string;
+  label: string;
+  fmt: (x: number) => string;
+}
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
 const PARQUET_URL = "/data/analytics/vessel_features_synthetic.parquet";
 
-const INDICATORS = [
-  { key: "ais_gap_count_30d",      label: "AIS gaps (30d)",          max: 60,  fmt: v => `${v} gaps`,     risk: "higher = worse" },
-  { key: "ais_gap_max_hours",      label: "Max gap duration",         max: 480, fmt: v => `${v}h`,          risk: "higher = worse" },
-  { key: "sts_candidate_count",    label: "STS transfers",            max: 12,  fmt: v => `${v}`,           risk: "higher = worse" },
-  { key: "loitering_hours_30d",    label: "Loitering (30d)",          max: 300, fmt: v => `${v}h`,          risk: "higher = worse" },
-  { key: "sanctions_distance",     label: "Sanctions distance",       max: 10,  fmt: v => `${v} hops`,      risk: "lower = worse", invert: true },
-  { key: "cluster_sanctions_ratio",label: "Cluster sanctions ratio",  max: 1,   fmt: v => `${(v*100).toFixed(0)}%`, risk: "higher = worse" },
-  { key: "flag_changes_2y",        label: "Flag changes (2yr)",       max: 4,   fmt: v => `${v}`,           risk: "higher = worse" },
-  { key: "ownership_depth",        label: "Ownership depth",          max: 10,  fmt: v => `${v} layers`,    risk: "higher = worse" },
-  { key: "sanctions_list_count",   label: "Sanctions list hits",      max: 3,   fmt: v => `${v}`,           risk: "higher = worse" },
+const INDICATORS: Indicator[] = [
+  { key: "ais_gap_count_30d",       label: "AIS gaps (30d)",         max: 60,  fmt: v => `${v} gaps`,                risk: "higher = worse" },
+  { key: "ais_gap_max_hours",       label: "Max gap duration",        max: 480, fmt: v => `${v}h`,                    risk: "higher = worse" },
+  { key: "sts_candidate_count",     label: "STS transfers",           max: 12,  fmt: v => `${v}`,                     risk: "higher = worse" },
+  { key: "loitering_hours_30d",     label: "Loitering (30d)",         max: 300, fmt: v => `${v}h`,                    risk: "higher = worse" },
+  { key: "sanctions_distance",      label: "Sanctions distance",      max: 10,  fmt: v => `${v} hops`,                risk: "lower = worse", invert: true },
+  { key: "cluster_sanctions_ratio", label: "Cluster sanctions ratio", max: 1,   fmt: v => `${(v * 100).toFixed(0)}%`, risk: "higher = worse" },
+  { key: "flag_changes_2y",         label: "Flag changes (2yr)",      max: 4,   fmt: v => `${v}`,                     risk: "higher = worse" },
+  { key: "ownership_depth",         label: "Ownership depth",         max: 10,  fmt: v => `${v} layers`,              risk: "higher = worse" },
+  { key: "sanctions_list_count",    label: "Sanctions list hits",     max: 3,   fmt: v => `${v}`,                     risk: "higher = worse" },
 ];
 
 // ── DuckDB init ───────────────────────────────────────────────────────────────
 
-async function initDB() {
-  const status = document.getElementById("db-status");
+async function initDB(): Promise<duckdb.AsyncDuckDBConnection> {
+  const status = document.getElementById("db-status")!;
   status.textContent = "Loading database…";
 
-  const BUNDLES = duckdb.getJsDelivrBundles();
-  const bundle = await duckdb.selectBundle(BUNDLES);
-
+  const bundle = await duckdb.selectBundle(duckdb.getJsDelivrBundles());
   const workerUrl = URL.createObjectURL(
-    new Blob([`importScripts("${bundle.mainWorker}");`], { type: "text/javascript" })
+    new Blob([`importScripts("${bundle.mainWorker!}");`], { type: "text/javascript" }),
   );
   const worker = new Worker(workerUrl);
   const logger = new duckdb.ConsoleLogger(duckdb.LogLevel.WARNING);
@@ -49,7 +86,7 @@ async function initDB() {
   await conn.query(`CREATE TABLE vessels AS SELECT * FROM read_parquet('vessels.parquet')`);
 
   const row = await conn.query(`SELECT COUNT(*) AS n FROM vessels`);
-  const n = row.toArray()[0].n;
+  const n = Number(row.toArray()[0].n);
   status.textContent = `${n} vessels loaded`;
 
   return conn;
@@ -57,50 +94,43 @@ async function initDB() {
 
 // ── Fleet overview ────────────────────────────────────────────────────────────
 
-async function renderFleetOverview(conn) {
-  const result = await conn.query(`
-    SELECT tier, COUNT(*) AS cnt
-    FROM vessels GROUP BY tier
-  `);
-  const counts = { low: 0, medium: 0, high: 0 };
-  for (const row of result.toArray()) counts[row.tier] = Number(row.cnt);
+async function renderFleetOverview(conn: duckdb.AsyncDuckDBConnection): Promise<void> {
+  const result = await conn.query(`SELECT tier, COUNT(*) AS cnt FROM vessels GROUP BY tier`);
+  const counts: Record<string, number> = { low: 0, medium: 0, high: 0 };
+  for (const row of result.toArray()) counts[row.tier as string] = Number(row.cnt);
 
-  document.getElementById("cnt-low").textContent  = counts.low;
-  document.getElementById("cnt-med").textContent  = counts.medium;
-  document.getElementById("cnt-high").textContent = counts.high;
+  (document.getElementById("cnt-low")  as HTMLElement).textContent = String(counts.low);
+  (document.getElementById("cnt-med")  as HTMLElement).textContent = String(counts.medium);
+  (document.getElementById("cnt-high") as HTMLElement).textContent = String(counts.high);
 
-  // Score distribution chart
   const dist = await conn.query(`
-    SELECT
-      FLOOR(behavioral_score / 10) * 10 AS bucket,
-      COUNT(*) AS cnt
-    FROM vessels
-    GROUP BY bucket ORDER BY bucket
+    SELECT FLOOR(behavioral_score / 10) * 10 AS bucket, COUNT(*) AS cnt
+    FROM vessels GROUP BY bucket ORDER BY bucket
   `);
   const distData = dist.toArray().map(r => ({ bucket: Number(r.bucket), cnt: Number(r.cnt) }));
 
   const chart = Plot.plot({
     width: 280, height: 130,
     marginLeft: 28, marginBottom: 24, marginTop: 8, marginRight: 8,
-    style: { background: "transparent", color: "#8b949e", fontSize: 11 },
-    x: { label: "Risk score", tickFormat: d => d },
-    y: { label: null, tickFormat: d => d },
+    style: { background: "transparent", color: "#8b949e", fontSize: "11px" },
+    x: { label: "Risk score", tickFormat: (d: unknown) => String(d) },
+    y: { label: null, tickFormat: (d: unknown) => String(d) },
     marks: [
       Plot.barY(distData, {
         x: "bucket",
         y: "cnt",
-        fill: d => d.bucket >= 60 ? "#f85149" : d.bucket >= 30 ? "#d29922" : "#3fb950",
+        fill: (d: { bucket: number }) => d.bucket >= 60 ? "#f85149" : d.bucket >= 30 ? "#d29922" : "#3fb950",
         dx: 2,
       }),
       Plot.ruleY([0], { stroke: "#30363d" }),
-    ]
+    ],
   });
-  document.getElementById("dist-chart").replaceChildren(chart);
+  document.getElementById("dist-chart")!.replaceChildren(chart);
 }
 
 // ── Vessel list ───────────────────────────────────────────────────────────────
 
-async function renderVesselList(conn, filter = "") {
+async function renderVesselList(conn: duckdb.AsyncDuckDBConnection, filter = ""): Promise<void> {
   const like = filter.replace(/'/g, "''");
   const result = await conn.query(`
     SELECT mmsi, vessel_name, flag_state, behavioral_score, tier
@@ -109,11 +139,11 @@ async function renderVesselList(conn, filter = "") {
     ORDER BY behavioral_score DESC
     LIMIT 60
   `);
-  const vessels = result.toArray();
-  const list = document.getElementById("vessel-list");
+  const vessels = result.toArray() as VesselRow[];
+  const list = document.getElementById("vessel-list")!;
   list.innerHTML = "";
 
-  const active = document.querySelector(".vessel-item.active")?.dataset.mmsi;
+  const active = document.querySelector<HTMLElement>(".vessel-item.active")?.dataset.mmsi;
 
   for (const v of vessels) {
     const el = document.createElement("div");
@@ -131,16 +161,15 @@ async function renderVesselList(conn, filter = "") {
 
 // ── Scorecard ─────────────────────────────────────────────────────────────────
 
-async function selectVessel(conn, mmsi) {
-  document.querySelectorAll(".vessel-item").forEach(el => {
+async function selectVessel(conn: duckdb.AsyncDuckDBConnection, mmsi: string): Promise<void> {
+  document.querySelectorAll<HTMLElement>(".vessel-item").forEach(el => {
     el.classList.toggle("active", el.dataset.mmsi === mmsi);
   });
 
   const result = await conn.query(`SELECT * FROM vessels WHERE mmsi = '${mmsi}'`);
-  const v = result.toArray()[0];
+  const v = result.toArray()[0] as VesselRow | undefined;
   if (!v) return;
 
-  // Cohort percentile: rank among same flag + type
   const pctResult = await conn.query(`
     SELECT
       ROUND(100.0 * SUM(CASE WHEN behavioral_score <= ${v.behavioral_score} THEN 1 ELSE 0 END) / COUNT(*), 0) AS pct
@@ -149,39 +178,32 @@ async function selectVessel(conn, mmsi) {
   `);
   const pct = Number(pctResult.toArray()[0].pct);
 
-  // Show scorecard
-  document.getElementById("no-selection").style.display = "none";
-  document.getElementById("scorecard").style.display = "block";
+  document.getElementById("no-selection")!.style.display = "none";
+  document.getElementById("scorecard")!.style.display = "block";
 
   const score = Number(v.behavioral_score);
   const tier = v.tier;
 
-  document.getElementById("sc-title").childNodes[0].textContent = v.vessel_name + " ";
-  document.getElementById("sc-mmsi").textContent = `MMSI ${v.mmsi}`;
+  document.getElementById("sc-title")!.childNodes[0].textContent = v.vessel_name + " ";
+  document.getElementById("sc-mmsi")!.textContent = `MMSI ${v.mmsi}`;
   updateDocumarisLink(v.mmsi);
-  document.getElementById("sc-score").textContent = score.toFixed(1);
-  document.getElementById("sc-tier").textContent = tier === "high" ? "HIGH RISK" : tier === "medium" ? "MEDIUM RISK" : "LOW RISK";
-  const scoreBox = document.getElementById("sc-score-box");
-  scoreBox.className = "score-box " + (tier === "high" ? "score-high" : tier === "medium" ? "score-medium" : "score-low");
+  document.getElementById("sc-score")!.textContent = score.toFixed(1);
+  document.getElementById("sc-tier")!.textContent =
+    tier === "high" ? "HIGH RISK" : tier === "medium" ? "MEDIUM RISK" : "LOW RISK";
+  document.getElementById("sc-score-box")!.className =
+    "score-box " + (tier === "high" ? "score-high" : tier === "medium" ? "score-medium" : "score-low");
 
-  document.getElementById("sc-percentile").textContent = `${pct}th`;
-  document.getElementById("sc-cohort-desc").textContent =
-    `vs ${v.flag_state} ${v.vessel_type} cohort`;
+  document.getElementById("sc-percentile")!.textContent = `${pct}th`;
+  document.getElementById("sc-cohort-desc")!.textContent = `vs ${v.flag_state} ${v.vessel_type} cohort`;
+  document.getElementById("sc-meta")!.innerHTML = `${v.flag_state}<br>${v.vessel_type}<br>Built ${v.built_year}`;
+  document.getElementById("sc-cohort-marker")!.style.left = `${pct}%`;
 
-  document.getElementById("sc-meta").innerHTML =
-    `${v.flag_state}<br>${v.vessel_type}<br>Built ${v.built_year}`;
-
-  // Cohort bar marker
-  document.getElementById("sc-cohort-marker").style.left = `${pct}%`;
-
-  // Indicators
-  const grid = document.getElementById("sc-indicators");
+  const grid = document.getElementById("sc-indicators")!;
   grid.innerHTML = "";
+  const vRecord = v as unknown as Record<string, unknown>;
   for (const ind of INDICATORS) {
-    const raw = Number(v[ind.key]);
-    const norm = ind.invert
-      ? 1 - Math.min(raw / ind.max, 1)
-      : Math.min(raw / ind.max, 1);
+    const raw = Number(vRecord[ind.key]);
+    const norm = ind.invert ? 1 - Math.min(raw / ind.max, 1) : Math.min(raw / ind.max, 1);
     const pctBar = Math.round(norm * 100);
     const barClass = pctBar >= 60 ? "bar-high" : pctBar >= 30 ? "bar-medium" : "bar-low";
     const row = document.createElement("div");
@@ -194,12 +216,11 @@ async function selectVessel(conn, mmsi) {
     grid.appendChild(row);
   }
 
-  // Premium comparison
   const traditional = Number(v.traditional_premium_usd);
-  const behavioral  = Number(v.behavioral_premium_usd);
-  const deltaPct    = (((behavioral - traditional) / traditional) * 100).toFixed(0);
+  const behavioral = Number(v.behavioral_premium_usd);
+  const deltaPct = (((behavioral - traditional) / traditional) * 100).toFixed(0);
 
-  const signalRisk = (key, val) => {
+  const signalRisk = (key: string, val: number): RiskLevel => {
     if (key === "ais_gap_count_30d")   return val > 10 ? "high" : val > 3  ? "med" : "ok";
     if (key === "sts_candidate_count") return val > 2  ? "high" : val > 0  ? "med" : "ok";
     if (key === "sanctions_distance")  return val <= 2 ? "high" : val <= 4 ? "med" : "ok";
@@ -207,7 +228,7 @@ async function selectVessel(conn, mmsi) {
     return "ok";
   };
 
-  const SIGNALS = [
+  const SIGNALS: Signal[] = [
     { key: "ais_gap_count_30d",   label: "AIS gaps (30d)",     fmt: x => `${x} gaps` },
     { key: "sts_candidate_count", label: "STS transfers",       fmt: x => `${x}` },
     { key: "sanctions_distance",  label: "Sanctions proximity", fmt: x => `${x} hops` },
@@ -215,7 +236,7 @@ async function selectVessel(conn, mmsi) {
   ];
 
   const signalsHtml = SIGNALS.map(s => {
-    const val = Number(v[s.key]);
+    const val = Number(vRecord[s.key]);
     const risk = signalRisk(s.key, val);
     return `<div class="prem-signal risk-${risk}">
       <div class="prem-signal-name">${s.label}</div>
@@ -223,7 +244,7 @@ async function selectVessel(conn, mmsi) {
     </div>`;
   }).join("");
 
-  document.getElementById("sc-premium-comparison").innerHTML = `
+  document.getElementById("sc-premium-comparison")!.innerHTML = `
     <div class="prem-tier">
       <div class="prem-tier-label">Traditional underwriting</div>
       <div class="prem-tier-factors">Flag state · Vessel age · Vessel type</div>
@@ -254,14 +275,12 @@ const conn = await initDB();
 await renderFleetOverview(conn);
 await renderVesselList(conn);
 
-// Auto-select: URL param (?mmsi=) takes priority, falls back to demo spotlight
 const autoMmsi = new URLSearchParams(location.search).get("mmsi") ?? "563012345";
 await selectVessel(conn, autoMmsi);
 if (location.search.includes("mmsi=")) {
   document.querySelector(".vessel-item.active")?.scrollIntoView({ block: "center", behavior: "smooth" });
 }
 
-// Search
-document.getElementById("vessel-search").addEventListener("input", e => {
-  renderVesselList(conn, e.target.value);
+document.getElementById("vessel-search")!.addEventListener("input", (e) => {
+  renderVesselList(conn, (e.target as HTMLInputElement).value);
 });

--- a/analytics/analysis/index.html
+++ b/analytics/analysis/index.html
@@ -256,6 +256,6 @@
     </main>
   </div>
 
-  <script type="module" src="app.js"></script>
+  <script type="module" src="app.ts"></script>
 </body>
 </html>

--- a/analytics/audit.html
+++ b/analytics/audit.html
@@ -109,6 +109,6 @@
     </div>
   </div>
 
-  <script type="module" src="audit.js"></script>
+  <script type="module" src="audit.ts"></script>
 </body>
 </html>

--- a/analytics/audit.ts
+++ b/analytics/audit.ts
@@ -1,17 +1,42 @@
-// EdgeSentry Audit Chain — audit.js
-// Fetches AuditRecord JSON from clarus-dev-public-audit, verifies hash chain
-// integrity, and renders a tamper-evidence timeline.
+// EdgeSentry Audit Chain — audit.ts
+export {}; // make this a module so top-level await and const status don't conflict with globals
 
-const status = document.getElementById("status");
+interface AuditRecord {
+  sequence: number;
+  timestamp_ms: number | string;
+  rule_id?: string;
+  object_ref?: string;
+  evidence_quality?: string;
+  confidence_cv?: number | string;
+  record_hash_hex?: string;
+  prev_record_hash_hex?: string;
+  payload_hash_hex?: string;
+  signature_hex?: string;
+  device_id?: string;
+  entity_ids?: string | string[];
+}
+
+interface AuditIndex {
+  keys: string[];
+  sites: string[];
+}
+
+interface VerifyResult {
+  gaps: number;
+  hashFails: number;
+  intact: boolean;
+}
+
+const status = document.getElementById("status") as HTMLElement;
 
 // ── Fetch + parse ─────────────────────────────────────────────────────────────
 
-async function fetchIndex(site) {
+async function fetchIndex(site: string | null): Promise<AuditIndex> {
   const url = site ? `/api/audit-index?site=${site}` : "/api/audit-index";
   return fetch(url).then(r => r.json()).catch(() => ({ keys: [], sites: [] }));
 }
 
-async function fetchRecord(key) {
+async function fetchRecord(key: string): Promise<AuditRecord | null> {
   const resp = await fetch(`/data/audit/${key}`);
   if (!resp.ok) return null;
   return resp.json();
@@ -19,7 +44,7 @@ async function fetchRecord(key) {
 
 // ── Chain verification ────────────────────────────────────────────────────────
 
-function verifyChain(records) {
+function verifyChain(records: AuditRecord[]): VerifyResult {
   let gaps = 0, hashFails = 0;
   for (let i = 0; i < records.length; i++) {
     if (i === 0) continue;
@@ -31,19 +56,19 @@ function verifyChain(records) {
 
 // ── Integrity banner ──────────────────────────────────────────────────────────
 
-function renderBanner(n, { intact, gaps, hashFails }) {
-  const banner = document.getElementById("integrity-banner");
-  const icon   = banner.querySelector(".integrity-icon");
-  const title  = banner.querySelector(".integrity-title");
-  const sub    = document.getElementById("integrity-sub");
+function renderBanner(n: number, { intact, gaps, hashFails }: VerifyResult): void {
+  const banner = document.getElementById("integrity-banner")!;
+  const icon   = banner.querySelector(".integrity-icon") as HTMLElement;
+  const title  = banner.querySelector(".integrity-title") as HTMLElement;
+  const sub    = document.getElementById("integrity-sub")!;
 
   if (intact) {
-    banner.className = "integrity-banner intact";
+    banner.className  = "integrity-banner intact";
     icon.textContent  = "✅";
     title.textContent = `Chain intact — ${n} record${n !== 1 ? "s" : ""}, 0 gaps`;
     sub.textContent   = "All prev_record_hash values match. No records deleted or modified.";
   } else {
-    banner.className = "integrity-banner broken";
+    banner.className  = "integrity-banner broken";
     icon.textContent  = "❌";
     title.textContent = "Chain integrity failure";
     sub.textContent   = [
@@ -55,7 +80,7 @@ function renderBanner(n, { intact, gaps, hashFails }) {
 
 // ── Table render ──────────────────────────────────────────────────────────────
 
-function qualClass(q) {
+function qualClass(q: string | undefined): string {
   if (!q) return "";
   const lower = q.toLowerCase();
   if (lower === "certified") return "qual-certified";
@@ -63,27 +88,24 @@ function qualClass(q) {
   return "qual-rejected";
 }
 
-function renderTable(records) {
-  const container = document.getElementById("chain-container");
-  document.getElementById("record-count").textContent = `${records.length} record(s)`;
+function renderTable(records: AuditRecord[]): void {
+  const container = document.getElementById("chain-container")!;
+  document.getElementById("record-count")!.textContent = `${records.length} record(s)`;
 
   if (records.length === 0) {
     container.innerHTML = '<div class="empty">No records found for this site.</div>';
     return;
   }
 
-  // Show newest first
   const sorted = [...records].reverse();
-
   const table = document.createElement("table");
   table.className = "chain-table";
   table.innerHTML = `<thead><tr>
     <th>Seq</th><th>Time (UTC)</th><th>Rule</th><th>Quality</th>
     <th>Confidence</th><th>Record hash</th><th>Chain link</th>
   </tr></thead><tbody></tbody>`;
-  const tbody = table.querySelector("tbody");
+  const tbody = table.querySelector("tbody")!;
 
-  // Build a lookup by sequence for chain link display
   const bySeq = Object.fromEntries(records.map(r => [r.sequence, r]));
 
   for (const r of sorted) {
@@ -92,8 +114,7 @@ function renderTable(records) {
       : "—";
     const hashShort = r.record_hash_hex ? r.record_hash_hex.slice(0, 12) + "…" : "—";
 
-    // Chain link verification
-    let linkHtml;
+    let linkHtml: string;
     if (r.sequence === 0) {
       linkHtml = `<span class="link-genesis">genesis</span>`;
     } else {
@@ -116,7 +137,6 @@ function renderTable(records) {
       <td>${linkHtml}</td>
     `;
 
-    // Expandable detail row
     const detailRow = document.createElement("tr");
     detailRow.className = "detail-row";
     detailRow.style.display = "none";
@@ -129,24 +149,22 @@ function renderTable(records) {
     detailTd.innerHTML = `<div class="detail-grid">
       <span class="detail-label">Device</span>
       <span class="detail-val">${r.device_id ?? "—"}</span>
-
       <span class="detail-label">Record hash</span>
       <span class="detail-val">${r.record_hash_hex ?? "—"}</span>
-
       <span class="detail-label">Prev hash</span>
       <span class="detail-val">${r.prev_record_hash_hex ?? "—"}</span>
-
       <span class="detail-label">Chain link</span>
       <span class="detail-val ${chainOk ? "ok" : "fail"}">
-        ${r.sequence === 0 ? "genesis — no previous record" : chainOk ? "✓ prev_hash matches record[" + (r.sequence - 1) + "].record_hash" : "✗ hash mismatch — record may have been tampered"}
+        ${r.sequence === 0
+          ? "genesis — no previous record"
+          : chainOk
+            ? `✓ prev_hash matches record[${r.sequence - 1}].record_hash`
+            : "✗ hash mismatch — record may have been tampered"}
       </span>
-
       <span class="detail-label">Payload hash</span>
       <span class="detail-val">${r.payload_hash_hex ?? "—"}</span>
-
       <span class="detail-label">Signature</span>
       <span class="detail-val">${r.signature_hex ? r.signature_hex.slice(0, 32) + "…" : "—"}</span>
-
       <span class="detail-label">Entity IDs</span>
       <span class="detail-val">${Array.isArray(r.entity_ids) ? r.entity_ids.join(", ") : (r.entity_ids ?? "—")}</span>
     </div>`;
@@ -166,7 +184,7 @@ function renderTable(records) {
 
 // ── Site selector ─────────────────────────────────────────────────────────────
 
-async function loadSite(site) {
+async function loadSite(site: string): Promise<void> {
   status.textContent = `Fetching chain for ${site}…`;
   const { keys } = await fetchIndex(site);
 
@@ -178,7 +196,7 @@ async function loadSite(site) {
   }
 
   status.textContent = `Loading ${keys.length} record(s)…`;
-  const records = (await Promise.all(keys.map(fetchRecord))).filter(Boolean);
+  const records = (await Promise.all(keys.map(fetchRecord))).filter((r): r is AuditRecord => r !== null);
   records.sort((a, b) => (a.sequence ?? 0) - (b.sequence ?? 0));
 
   const result = verifyChain(records);
@@ -193,19 +211,18 @@ status.textContent = "Fetching index…";
 const { keys, sites } = await fetchIndex(null);
 
 if (keys.length === 0) {
-  document.getElementById("no-data").style.display = "flex";
+  (document.getElementById("no-data") as HTMLElement).style.display = "flex";
   status.textContent = "No records";
 } else {
-  document.getElementById("audit-content").style.display = "block";
+  (document.getElementById("audit-content") as HTMLElement).style.display = "block";
 
-  const sel = document.getElementById("site-select");
+  const sel = document.getElementById("site-select") as HTMLSelectElement;
   for (const s of sites) {
     const opt = document.createElement("option");
     opt.value = opt.textContent = s;
     sel.appendChild(opt);
   }
 
-  // Auto-select from URL param or first site
   const urlSite = new URLSearchParams(location.search).get("site");
   if (urlSite && sites.includes(urlSite)) sel.value = urlSite;
 

--- a/analytics/live.html
+++ b/analytics/live.html
@@ -130,6 +130,6 @@
     </div>
   </div>
 
-  <script type="module" src="live.js"></script>
+  <script type="module" src="live.ts"></script>
 </body>
 </html>

--- a/analytics/live.ts
+++ b/analytics/live.ts
@@ -1,10 +1,40 @@
-// EdgeSentry Operations Monitor — live.js
-import * as duckdb from "https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@1.29.0/+esm";
-import * as Plot   from "https://cdn.jsdelivr.net/npm/@observablehq/plot@0.6/+esm";
+// EdgeSentry Operations Monitor — live.ts
+
+import * as duckdb from "@duckdb/duckdb-wasm";
+import * as Plot from "@observablehq/plot";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface AlertRow {
+  timestamp_ms: number | string;
+  site_id: string;
+  rule_id: string;
+  severity: string;
+  evidence_quality: string;
+  confidence_cv: number | string;
+  measured_value: number | string;
+  threshold: number | string;
+  entity_ids: string;
+  sequence?: number;
+}
+
+interface HeartbeatRow {
+  timestamp_ms: number | string;
+  site_id: string;
+  calibration_status: string;
+  drift_score: number | string;
+  certified_count: number | string;
+  degraded_count: number | string;
+  rejected_count: number | string;
+}
+
+interface LiveIndex {
+  heartbeats: string[];
+  alerts: string[];
+  sites: string[];
+}
 
 // ── LLM alert explanation ─────────────────────────────────────────────────────
-// Calls local llama.cpp via Caddy HTTPS proxy (run_llama.sh starts both).
-// Caches results in DuckDB WASM so each alert is only explained once.
 
 const LLM_ENDPOINT = "https://localhost:8443/v1/chat/completions";
 const LLM_TIMEOUT_MS = 30_000;
@@ -17,7 +47,7 @@ const SYSTEM_PROMPT =
   "STRICT: no mention of evidence quality, confidence, or admissibility — that will be added separately. " +
   "No markdown. No bullet points. Maximum 2 sentences.";
 
-function buildAlertPrompt(r) {
+function buildAlertPrompt(r: AlertRow): string {
   const entities = (() => { try { return JSON.parse(r.entity_ids).join(", "); } catch { return r.entity_ids; } })();
   const qualNote = r.evidence_quality === "Certified"
     ? "CERTIFIED — full evidential weight, admissible"
@@ -35,7 +65,7 @@ function buildAlertPrompt(r) {
   ].join("\n");
 }
 
-async function initExplainCache(conn) {
+async function initExplainCache(conn: duckdb.AsyncDuckDBConnection): Promise<void> {
   await conn.query(`
     CREATE TABLE IF NOT EXISTS alert_explanations (
       cache_key  TEXT PRIMARY KEY,
@@ -45,28 +75,27 @@ async function initExplainCache(conn) {
   `);
 }
 
-function alertCacheKey(r) {
+function alertCacheKey(r: AlertRow): string {
   return `${r.site_id}:${r.rule_id}:${r.timestamp_ms}`;
 }
 
-async function getCachedExplanation(conn, key) {
+async function getCachedExplanation(conn: duckdb.AsyncDuckDBConnection, key: string): Promise<string | null> {
   const res = await conn.query(
-    `SELECT explanation FROM alert_explanations WHERE cache_key = '${key.replace(/'/g,"''")}' LIMIT 1`
+    `SELECT explanation FROM alert_explanations WHERE cache_key = '${key.replace(/'/g, "''")}' LIMIT 1`
   );
   const rows = res.toArray();
-  return rows.length > 0 ? rows[0].explanation : null;
+  return rows.length > 0 ? rows[0].explanation as string : null;
 }
 
-async function saveExplanation(conn, key, text) {
+async function saveExplanation(conn: duckdb.AsyncDuckDBConnection, key: string, text: string): Promise<void> {
   await conn.query(`
     INSERT INTO alert_explanations (cache_key, explanation)
-    VALUES ('${key.replace(/'/g,"''")}', '${text.replace(/'/g,"''")}')
+    VALUES ('${key.replace(/'/g, "''")}', '${text.replace(/'/g, "''")}')
     ON CONFLICT (cache_key) DO UPDATE SET explanation = excluded.explanation, generated_at = now()
   `);
 }
 
-// Build the evidence quality sentence deterministically — never trust the LLM for this.
-function evidenceQualitySentence(r) {
+function evidenceQualitySentence(r: AlertRow): string {
   const conf = Number(r.confidence_cv).toFixed(2);
   switch (r.evidence_quality) {
     case "Certified":
@@ -78,7 +107,7 @@ function evidenceQualitySentence(r) {
   }
 }
 
-async function fetchExplanation(row) {
+async function fetchExplanation(row: AlertRow): Promise<string> {
   const ac = new AbortController();
   const timer = setTimeout(() => ac.abort(), LLM_TIMEOUT_MS);
   try {
@@ -96,9 +125,8 @@ async function fetchExplanation(row) {
       signal: ac.signal,
     });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const data = await res.json();
+    const data = await res.json() as { choices?: Array<{ message?: { content?: string } }> };
     const llmText = (data?.choices?.[0]?.message?.content ?? "").trim();
-    // Inject the deterministic evidence quality sentence between LLM sentences 1 and 2.
     const sentences = llmText.split(/(?<=\.)\s+/);
     const s1 = sentences[0] ?? llmText;
     const rest = sentences.slice(1).join(" ");
@@ -108,25 +136,25 @@ async function fetchExplanation(row) {
   }
 }
 
-// Entity → MMSI mapping for Flow 1→2 demo navigation
-const VESSEL_MMSI = { "V-001": "563012345" };
+const VESSEL_MMSI: Record<string, string> = { "V-001": "563012345" };
 
-const status = document.getElementById("db-status");
+const status = document.getElementById("db-status") as HTMLElement;
 
 // ── DuckDB init ───────────────────────────────────────────────────────────────
 
-async function initDB() {
+async function initDB(): Promise<duckdb.AsyncDuckDB> {
   status.textContent = "Initialising database…";
   const bundle = await duckdb.selectBundle(duckdb.getJsDelivrBundles());
   const workerUrl = URL.createObjectURL(
-    new Blob([`importScripts("${bundle.mainWorker}");`], { type: "text/javascript" })
+    new Blob([`importScripts("${bundle.mainWorker!}");`], { type: "text/javascript" }),
   );
-  const db = new duckdb.AsyncDuckDB(new duckdb.ConsoleLogger(duckdb.LogLevel.WARNING), new Worker(workerUrl));
+  const db = new duckdb.AsyncDuckDB(
+    new duckdb.ConsoleLogger(duckdb.LogLevel.WARNING),
+    new Worker(workerUrl),
+  );
   await db.instantiate(bundle.mainModule, bundle.pthreadWorker);
   URL.revokeObjectURL(workerUrl);
 
-  // Persist alert_explanations cache across page reloads via OPFS.
-  // Falls back to in-memory if OPFS is unavailable (Safari Private mode).
   try {
     await db.open({ path: "opfs://clarus-analytics.db" });
     status.textContent = "Database ready (persistent)";
@@ -138,9 +166,14 @@ async function initDB() {
   return db;
 }
 
-async function loadParquetFiles(db, conn, keys, tableName) {
+async function loadParquetFiles(
+  db: duckdb.AsyncDuckDB,
+  conn: duckdb.AsyncDuckDBConnection,
+  keys: string[],
+  tableName: string,
+): Promise<boolean> {
   if (keys.length === 0) return false;
-  const fnames = [];
+  const fnames: string[] = [];
   for (const [i, key] of keys.entries()) {
     const resp = await fetch(`/data/raw/${key}`);
     if (!resp.ok) continue;
@@ -158,20 +191,19 @@ async function loadParquetFiles(db, conn, keys, tableName) {
 
 // ── Site selector ─────────────────────────────────────────────────────────────
 
-let selectedSite = null; // null = all sites
+let selectedSite: string | null = null;
 
-function siteWhere(alias = "") {
+function siteWhere(alias = ""): string {
   const prefix = alias ? `${alias}.` : "";
   return selectedSite ? `${prefix}site_id = '${selectedSite}'` : "1=1";
 }
 
-// ── Site status cards (clickable) ─────────────────────────────────────────────
+// ── Site status cards ─────────────────────────────────────────────────────────
 
-async function renderSiteStatus(conn, sites) {
-  const grid = document.getElementById("site-grid");
+async function renderSiteStatus(conn: duckdb.AsyncDuckDBConnection, sites: string[]): Promise<void> {
+  const grid = document.getElementById("site-grid")!;
   grid.innerHTML = "";
 
-  // "All" card
   const allCard = document.createElement("div");
   allCard.className = "site-card" + (selectedSite === null ? " selected" : "");
   allCard.dataset.site = "";
@@ -185,7 +217,7 @@ async function renderSiteStatus(conn, sites) {
       FROM heartbeats WHERE site_id = '${site}'
       ORDER BY timestamp_ms DESC LIMIT 1
     `);
-    const rows = res.toArray();
+    const rows = res.toArray() as HeartbeatRow[];
     if (rows.length === 0) continue;
     const r = rows[0];
     const cal = r.calibration_status;
@@ -199,13 +231,12 @@ async function renderSiteStatus(conn, sites) {
     card.innerHTML = `
       <div class="name"><span class="dot ${dotCls}"></span>${site}</div>
       <div class="status">${cal} &nbsp;·&nbsp; drift ${Number(r.drift_score).toFixed(3)} m</div>
-      <div class="meta">Last: ${ageStr} &nbsp;·&nbsp; ${r.total} events</div>
+      <div class="meta">Last: ${ageStr} &nbsp;·&nbsp; ${(r as unknown as Record<string, unknown>)["total"]} events</div>
     `;
     grid.appendChild(card);
   }
 
-  // Click handler
-  grid.querySelectorAll(".site-card").forEach(card => {
+  grid.querySelectorAll<HTMLElement>(".site-card").forEach(card => {
     card.addEventListener("click", async () => {
       selectedSite = card.dataset.site || null;
       await refreshCharts(conn, sites);
@@ -215,23 +246,23 @@ async function renderSiteStatus(conn, sites) {
 
 // ── Charts ────────────────────────────────────────────────────────────────────
 
-async function renderDriftChart(conn) {
+async function renderDriftChart(conn: duckdb.AsyncDuckDBConnection): Promise<void> {
   const res = await conn.query(`
     SELECT timestamp_ms, site_id, drift_score, calibration_status
     FROM heartbeats WHERE ${siteWhere()}
     ORDER BY timestamp_ms
   `);
   const data = res.toArray().map(r => ({
-    ts: new Date(Number(r.timestamp_ms)), site: r.site_id,
-    drift: Number(r.drift_score), status: r.calibration_status,
+    ts: new Date(Number(r.timestamp_ms)), site: r.site_id as string,
+    drift: Number(r.drift_score), status: r.calibration_status as string,
   }));
   const chart = Plot.plot({
     width: 520, height: 150,
     marginLeft: 42, marginBottom: 28, marginTop: 8, marginRight: 12,
-    style: { background: "transparent", color: "#8b949e", fontSize: 11 },
-    x: { label: null, tickFormat: d => `${d.getHours()}:${String(d.getMinutes()).padStart(2,"0")}` },
+    style: { background: "transparent", color: "#8b949e", fontSize: "11px" },
+    x: { label: null, tickFormat: (d: unknown) => { const date = d as Date; return `${date.getHours()}:${String(date.getMinutes()).padStart(2, "0")}`; } },
     y: { label: "drift (m)", domain: [0, 0.9] },
-    color: { domain: ["VALID","DEGRADED","UNCALIBRATED"], range: ["#3fb950","#d29922","#f85149"] },
+    color: { domain: ["VALID", "DEGRADED", "UNCALIBRATED"], range: ["#3fb950", "#d29922", "#f85149"] },
     marks: [
       Plot.ruleY([0.3], { stroke: "#d29922", strokeDasharray: "4 2", strokeWidth: 1 }),
       Plot.ruleY([0.6], { stroke: "#f85149", strokeDasharray: "4 2", strokeWidth: 1 }),
@@ -239,52 +270,52 @@ async function renderDriftChart(conn) {
       Plot.dot(data,  { x: "ts", y: "drift", fill: "status", r: 3 }),
     ],
   });
-  document.getElementById("drift-chart").replaceChildren(chart);
+  document.getElementById("drift-chart")!.replaceChildren(chart);
 }
 
-async function renderQualityChart(conn) {
+async function renderQualityChart(conn: duckdb.AsyncDuckDBConnection): Promise<void> {
   const res = await conn.query(`
     SELECT timestamp_ms, site_id, certified_count, degraded_count, rejected_count
     FROM heartbeats WHERE ${siteWhere()}
     ORDER BY timestamp_ms
   `);
   const data = res.toArray().flatMap(r => [
-    { ts: new Date(Number(r.timestamp_ms)), site: r.site_id, quality: "Certified", count: Number(r.certified_count) },
-    { ts: new Date(Number(r.timestamp_ms)), site: r.site_id, quality: "Degraded",  count: Number(r.degraded_count) },
-    { ts: new Date(Number(r.timestamp_ms)), site: r.site_id, quality: "Rejected",  count: Number(r.rejected_count) },
+    { ts: new Date(Number(r.timestamp_ms)), site: r.site_id as string, quality: "Certified", count: Number(r.certified_count) },
+    { ts: new Date(Number(r.timestamp_ms)), site: r.site_id as string, quality: "Degraded",  count: Number(r.degraded_count) },
+    { ts: new Date(Number(r.timestamp_ms)), site: r.site_id as string, quality: "Rejected",  count: Number(r.rejected_count) },
   ]);
   const chart = Plot.plot({
     width: 520, height: 150,
     marginLeft: 32, marginBottom: 28, marginTop: 8, marginRight: 12,
-    style: { background: "transparent", color: "#8b949e", fontSize: 11 },
-    x: { label: null, tickFormat: d => `${d.getHours()}:${String(d.getMinutes()).padStart(2,"0")}` },
+    style: { background: "transparent", color: "#8b949e", fontSize: "11px" },
+    x: { label: null, tickFormat: (d: unknown) => { const date = d as Date; return `${date.getHours()}:${String(date.getMinutes()).padStart(2, "0")}`; } },
     y: { label: "events" },
-    color: { domain: ["Certified","Degraded","Rejected"], range: ["#3fb950","#d29922","#f85149"] },
+    color: { domain: ["Certified", "Degraded", "Rejected"], range: ["#3fb950", "#d29922", "#f85149"] },
     marks: [
       Plot.barY(data, Plot.stackY({ x: "ts", y: "count", fill: "quality" })),
       Plot.ruleY([0], { stroke: "#30363d" }),
     ],
   });
-  document.getElementById("quality-chart").replaceChildren(chart);
+  document.getElementById("quality-chart")!.replaceChildren(chart);
 }
 
-async function populateRuleFilter(conn) {
+async function populateRuleFilter(conn: duckdb.AsyncDuckDBConnection): Promise<void> {
   const res = await conn.query(`SELECT DISTINCT rule_id FROM audit_chain ORDER BY rule_id`);
-  const sel = document.getElementById("filter-rule");
+  const sel = document.getElementById("filter-rule") as HTMLSelectElement;
   const existing = [...sel.options].map(o => o.value);
   for (const r of res.toArray()) {
-    if (!existing.includes(r.rule_id)) {
+    if (!existing.includes(r.rule_id as string)) {
       const opt = document.createElement("option");
-      opt.value = opt.textContent = r.rule_id;
+      opt.value = opt.textContent = r.rule_id as string;
       sel.appendChild(opt);
     }
   }
 }
 
-async function renderAlerts(conn) {
-  const rule     = document.getElementById("filter-rule")?.value     || "";
-  const severity = document.getElementById("filter-severity")?.value || "";
-  const quality  = document.getElementById("filter-quality")?.value  || "";
+async function renderAlerts(conn: duckdb.AsyncDuckDBConnection): Promise<void> {
+  const rule     = (document.getElementById("filter-rule")     as HTMLSelectElement)?.value || "";
+  const severity = (document.getElementById("filter-severity") as HTMLSelectElement)?.value || "";
+  const quality  = (document.getElementById("filter-quality")  as HTMLSelectElement)?.value || "";
 
   const conditions = [siteWhere()];
   if (rule)     conditions.push(`rule_id = '${rule}'`);
@@ -292,16 +323,15 @@ async function renderAlerts(conn) {
   if (quality)  conditions.push(`evidence_quality = '${quality}'`);
 
   const where = conditions.join(" AND ");
-
   const res = await conn.query(`
     SELECT timestamp_ms, site_id, rule_id, severity, evidence_quality,
            confidence_cv, measured_value, entity_ids
     FROM audit_chain WHERE ${where}
     ORDER BY timestamp_ms DESC LIMIT 100
   `);
-  const rows = res.toArray();
-  const container = document.getElementById("alert-container");
-  document.getElementById("filter-count").textContent = `${rows.length} row(s)`;
+  const rows = res.toArray() as AlertRow[];
+  const container = document.getElementById("alert-container")!;
+  document.getElementById("filter-count")!.textContent = `${rows.length} row(s)`;
 
   if (rows.length === 0) {
     container.innerHTML = '<div class="empty">No alerts match the current filter.</div>';
@@ -314,21 +344,23 @@ async function renderAlerts(conn) {
     <th>Time (UTC)</th><th>Site</th><th>Rule</th><th>Severity</th>
     <th>Quality</th><th>Confidence</th><th>Value</th><th>Entities</th><th></th>
   </tr></thead><tbody></tbody>`;
-  const tbody = table.querySelector("tbody");
+  const tbody = table.querySelector("tbody")!;
 
   for (const r of rows) {
     const qualCls = r.evidence_quality === "Certified" ? "qual-certified"
                   : r.evidence_quality === "Degraded"  ? "qual-degraded" : "qual-rejected";
     const sevCls  = r.severity === "Critical" ? "sev-critical" : "sev-high";
-    const entityArr = (() => { try { return JSON.parse(r.entity_ids); } catch { return [r.entity_ids ?? "—"]; } })();
+    const entityArr: string[] = (() => {
+      try { return JSON.parse(r.entity_ids) as string[]; }
+      catch { return [r.entity_ids ?? "—"]; }
+    })();
     const entitiesHtml = entityArr.map(e => {
       const mmsi = VESSEL_MMSI[e];
       return mmsi
         ? `${e} <a href="/analysis/?mmsi=${mmsi}" style="color:var(--accent);font-size:10px;text-decoration:none" title="View vessel risk profile">→ profile</a>`
         : e;
     }).join(", ");
-    const ts = new Date(Number(r.timestamp_ms)).toISOString().replace("T"," ").slice(0,19) + " UTC";
-
+    const ts = new Date(Number(r.timestamp_ms)).toISOString().replace("T", " ").slice(0, 19) + " UTC";
     const auditLink = r.sequence != null
       ? `<a href="/audit?site=${r.site_id}&seq=${r.sequence}" style="color:var(--accent);font-size:10px;text-decoration:none;white-space:nowrap" title="View in audit chain">→ chain</a>`
       : "";
@@ -345,7 +377,6 @@ async function renderAlerts(conn) {
       <td>${auditLink}</td>
     `;
 
-    // Expandable explanation row
     const expRow = document.createElement("tr");
     expRow.className = "explain-row";
     expRow.style.display = "none";
@@ -357,50 +388,51 @@ async function renderAlerts(conn) {
     tr.addEventListener("click", async () => {
       const isOpen = expRow.style.display !== "none";
       if (isOpen) { expRow.style.display = "none"; return; }
-
       expRow.style.display = "table-row";
       expTd.innerHTML = `<span class="explain-loading">Thinking…</span>`;
 
       const key = alertCacheKey(r);
-      const cached = await getCachedExplanation(conn, key);
-      if (cached) { render(cached, true); return; }
 
       const vesselLink = entityArr.find(e => VESSEL_MMSI[e])
         ? (() => {
-            const e = entityArr.find(e => VESSEL_MMSI[e]);
+            const e = entityArr.find(e => VESSEL_MMSI[e])!;
             return ` <a href="/analysis/?mmsi=${VESSEL_MMSI[e]}" style="color:var(--accent);font-weight:600;text-decoration:none">View ${e} vessel risk profile →</a>`;
           })()
         : "";
 
-      const render = (text, fromCache) => {
+      const render = (text: string) => {
         expTd.innerHTML = `
           <div class="explain-inner">
             <span>${text}${vesselLink}</span>
             <button class="regen-btn" title="Regenerate explanation">↻</button>
           </div>
         `;
-        expTd.querySelector(".regen-btn").addEventListener("click", async (e) => {
+        expTd.querySelector<HTMLButtonElement>(".regen-btn")!.addEventListener("click", async (e) => {
           e.stopPropagation();
           expTd.innerHTML = `<span class="explain-loading">Regenerating…</span>`;
           try {
             const fresh = await fetchExplanation(r);
             await saveExplanation(conn, key, fresh);
-            render(fresh, false);
+            render(fresh);
           } catch (err) {
-            expTd.innerHTML = `<span style="color:var(--red)">Error: ${err.message}</span>`;
+            expTd.innerHTML = `<span style="color:var(--red)">Error: ${(err as Error).message}</span>`;
           }
         });
       };
 
+      const cached = await getCachedExplanation(conn, key);
+      if (cached) { render(cached); return; }
+
       try {
         const text = await fetchExplanation(r);
         await saveExplanation(conn, key, text);
-        render(text, false);
+        render(text);
       } catch (e) {
-        const isOffline = e.name === "AbortError" || e.message.includes("fetch") || e.message.includes("Load failed");
+        const err = e as Error;
+        const isOffline = err.name === "AbortError" || err.message.includes("fetch") || err.message.includes("Load failed");
         expTd.innerHTML = isOffline
           ? `<span style="color:var(--amber)">LLM offline — run <code>./scripts/run_llama.sh</code> to enable explanations</span>`
-          : `<span style="color:var(--red)">Error: ${e.message}</span>`;
+          : `<span style="color:var(--red)">Error: ${err.message}</span>`;
       }
     });
 
@@ -410,9 +442,7 @@ async function renderAlerts(conn) {
   container.replaceChildren(table);
 }
 
-// ── Refresh all charts with current site filter ───────────────────────────────
-
-async function refreshCharts(conn, sites) {
+async function refreshCharts(conn: duckdb.AsyncDuckDBConnection, sites: string[]): Promise<void> {
   await renderSiteStatus(conn, sites);
   await renderDriftChart(conn);
   await renderQualityChart(conn);
@@ -426,34 +456,34 @@ const conn = await db.connect();
 
 status.textContent = "Fetching live index…";
 const { heartbeats: hbKeys, alerts: alertKeys, sites } =
-  await fetch("/api/live-index").then(r => r.json())
-  .catch(() => ({ heartbeats: [], alerts: [], sites: [] }));
+  await fetch("/api/live-index").then(r => r.json() as Promise<LiveIndex>)
+  .catch((): LiveIndex => ({ heartbeats: [], alerts: [], sites: [] }));
 
 if (hbKeys.length === 0 && alertKeys.length === 0) {
-  document.getElementById("no-data").style.display = "flex";
+  (document.getElementById("no-data") as HTMLElement).style.display = "flex";
   status.textContent = "No data";
 } else {
-  document.getElementById("live-content").style.display = "block";
+  (document.getElementById("live-content") as HTMLElement).style.display = "block";
   status.textContent = `Loading ${hbKeys.length + alertKeys.length} file(s)…`;
 
-  const hasHB  = await loadParquetFiles(db, conn, hbKeys,    "heartbeats");
-  const hasAlt = await loadParquetFiles(db, conn, alertKeys, "audit_chain");
+  await loadParquetFiles(db, conn, hbKeys,    "heartbeats");
+  await loadParquetFiles(db, conn, alertKeys, "audit_chain");
 
-  const n = await conn.query("SELECT COUNT(*) AS n FROM heartbeats").then(r => r.toArray()[0]?.n ?? 0);
+  const n = await conn.query("SELECT COUNT(*) AS n FROM heartbeats")
+    .then(r => Number(r.toArray()[0]?.n ?? 0));
   status.textContent = `${n} heartbeats · ${sites.length} site(s)`;
 
   await initExplainCache(conn);
   await populateRuleFilter(conn);
   await refreshCharts(conn, sites);
 
-  // Alert filter listeners
   ["filter-rule", "filter-severity", "filter-quality"].forEach(id => {
     document.getElementById(id)?.addEventListener("change", () => renderAlerts(conn));
   });
-  document.getElementById("filter-clear")?.addEventListener("click", () => {
-    document.getElementById("filter-rule").value     = "";
-    document.getElementById("filter-severity").value = "";
-    document.getElementById("filter-quality").value  = "";
+  (document.getElementById("filter-clear") as HTMLButtonElement)?.addEventListener("click", () => {
+    (document.getElementById("filter-rule")     as HTMLSelectElement).value = "";
+    (document.getElementById("filter-severity") as HTMLSelectElement).value = "";
+    (document.getElementById("filter-quality")  as HTMLSelectElement).value = "";
     renderAlerts(conn);
   });
 }


### PR DESCRIPTION
Conflict-free rebase of #71 onto main (after #70 merged).

## Summary

Completes the TypeScript migration — no more plain JS source files in `analytics/`.

| File | Types added |
|------|-------------|
| `analysis/app.ts` | `VesselRow`, `RiskLevel`, `Indicator`, `Signal` |
| `audit.ts` | `AuditRecord`, `AuditIndex`, `VerifyResult` — `export {}` for module mode |
| `live.ts` | `AlertRow`, `HeartbeatRow`, `LiveIndex` |

CDN imports replaced with npm packages (`@duckdb/duckdb-wasm`, `@observablehq/plot`).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 4/4 pass
- [x] `npm run build` — all 4 pages in `dist/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)