### PR TITLE
chore: add .claude/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ data/**/*.parquet
 analytics/node_modules/
 analytics/dist/
 site/
+.claude/


### PR DESCRIPTION
Prevents Claude Code session directory from being accidentally committed.