### PR TITLE
refactor(docs): reframe clarus as profile-switchable safety monitoring

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,14 @@
 # AGENTS
 
-Tauri GUI application layer for [edgesentry-rs](https://github.com/edgesentry/edgesentry-rs). The engine, CLI, and all pipeline crates live in edgesentry-rs — no pipeline logic belongs here.
+Physics-based safety monitoring platform — application layer for [edgesentry-rs](https://github.com/edgesentry/edgesentry-rs). The active use case is determined by the loaded profile; the engine and binary are domain-agnostic.
+
+| Profile | Domain | Submission |
+|---|---|---|
+| `sg-port-safety/` | Port worker / forklift safety (MPA + MOM WSH) | PIER71-14 (primary) |
+| `sg-maritime-security/` | Vessel restricted zone + AIS gap | CAP Vista (dual-use) |
+| `demo/` | Generic OSS demo | — |
+
+The engine, CLI, and all pipeline crates live in edgesentry-rs — no pipeline logic belongs here.
 
 **Demo app:** [clarus.edgesentry.io](https://clarus.edgesentry.io/) (Cloudflare Pages — analytics web app)
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,19 @@
 # clarus
 
-Tauri GUI application for the [edgesentry-rs](https://github.com/edgesentry/edgesentry-rs) safety and compliance toolkit.
+Physics-based safety monitoring and compliance evidence platform. The same engine applies to any domain — the active use case is determined by the loaded profile.
+
+| Profile | Domain | Primary submission |
+|---|---|---|
+| `sg-port-safety/` | Port worker / forklift safety — MPA + MOM WSH | PIER71-14 |
+| `sg-maritime-security/` | Vessel restricted zone + AIS gap monitoring | CAP Vista (dual-use) |
+| `demo/` | Generic citations — OSS demo only | — |
 
 ## What's in this repo
 
 | Path | Purpose |
 |---|---|
 | `ui/` | Tauri desktop app (Vite frontend + Rust Tauri backend) |
-| `profiles/` | Demo regulatory profile (OSS, generic citations) |
+| `profiles/` | Per-domain rule sets, KB snippets, regulatory citations |
 | `fixtures/` | CSV fixtures for demo scenarios |
 | `scripts/` | Local dev and e2e test scripts |
 
@@ -21,15 +27,15 @@ eds assess / explain / report           renders reports, verifies
 eds audit sign / verify                 audit chains, manages profiles
 ```
 
-The Tauri backend calls edgesentry-rs crates via Cargo path dependencies — no separate process needed.
+The Tauri backend calls edgesentry-rs crates via Cargo path dependencies — no separate process needed. Switching domain = swapping `--profile <path>` at runtime; the binary is identical.
 
 ## Platform
 
 clarus and [documaris](https://github.com/edgesentry/documaris) form the EdgeSentry platform — both operate on the same vessel entity (MMSI):
 
 ```
-clarus (physical port safety)          documaris (port call documentation)
-─────────────────────────────          ───────────────────────────────────
+clarus (safety monitoring)             documaris (port call documentation)
+──────────────────────────             ───────────────────────────────────
 Near-miss detection · Physics alerts   FAL Form 1 · BWM certificate check
 Tamper-proof audit records             Compliance alerts · Audit record
 https://clarus.edgesentry.io/live      https://documaris.edgesentry.io/analysis/

--- a/README.md
+++ b/README.md
@@ -28,16 +28,16 @@ The Tauri backend calls edgesentry-rs crates via Cargo path dependencies — no 
 clarus and [documaris](https://github.com/edgesentry/documaris) form the EdgeSentry platform — both operate on the same vessel entity (MMSI):
 
 ```
-clarus (vessel risk intelligence)      documaris (port call documentation)
-─────────────────────────────────      ───────────────────────────────────
-AIS gaps · STS transfers               FAL Form 1 · BWM certificate check
-Behavioural risk score                 Compliance alerts · Audit record
-https://clarus.edgesentry.io/analysis/ https://documaris.edgesentry.io/analysis/
+clarus (physical port safety)          documaris (port call documentation)
+─────────────────────────────          ───────────────────────────────────
+Near-miss detection · Physics alerts   FAL Form 1 · BWM certificate check
+Tamper-proof audit records             Compliance alerts · Audit record
+https://clarus.edgesentry.io/live      https://documaris.edgesentry.io/analysis/
          │                                       │
          └──────────── same vessel (MMSI) ───────┘
 ```
 
-Both apps accept `?mmsi=<mmsi>` for deep-linking. The clarus scorecard links forward to the vessel's port call documents in documaris, and vice versa.
+Both apps accept `?mmsi=<mmsi>` for deep-linking. The clarus operations monitor links forward to the vessel's port call documents in documaris, and vice versa.
 
 ## Quick start
 

--- a/analytics/app.ts
+++ b/analytics/app.ts
@@ -1,4 +1,4 @@
-// EdgeSentry Vessel Risk Intelligence — app.ts
+// clarus port safety analytics — app.ts
 
 import * as duckdb from "@duckdb/duckdb-wasm";
 import * as Plot from "@observablehq/plot";

--- a/analytics/audit.html
+++ b/analytics/audit.html
@@ -74,8 +74,8 @@
     <h1>EdgeSentry Audit Chain</h1>
     <span class="badge">WORM</span>
     <nav class="nav">
-      <a href="/analysis/">Risk Intelligence</a>
       <a href="/live">Operations Monitor</a>
+      <a href="/analysis/">Analytics</a>
       <a href="/audit" class="active">Audit Chain</a>
     </nav>
     <span id="status" style="margin-left:16px">Loading…</span>

--- a/analytics/index.html
+++ b/analytics/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>EdgeSentry Vessel Risk Intelligence</title>
+  <title>clarus — Analytics</title>
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
@@ -160,11 +160,10 @@
 </head>
 <body>
   <header>
-    <h1>EdgeSentry Vessel Risk Intelligence</h1>
-    <span class="badge">Flow 2 MVP</span>
+    <h1>clarus — Analytics</h1>
     <nav class="nav">
-      <a href="/" class="active">Risk Intelligence</a>
       <a href="/live">Operations Monitor</a>
+      <a href="/" class="active">Analytics</a>
       <a href="/audit">Audit Chain</a>
     </nav>
     <span style="margin-left:16px;color:var(--muted);font-size:12px" id="db-status">Loading…</span>

--- a/analytics/live.html
+++ b/analytics/live.html
@@ -77,8 +77,8 @@
     <h1>EdgeSentry Operations Monitor</h1>
     <span class="badge">Flow 1 — Live</span>
     <nav class="nav">
-      <a href="/analysis/">Risk Intelligence</a>
       <a href="/live" class="active">Operations Monitor</a>
+      <a href="/analysis/">Analytics</a>
       <a href="/audit">Audit Chain</a>
     </nav>
     <span id="db-status" style="margin-left:16px">Loading…</span>

--- a/analytics/live.ts
+++ b/analytics/live.ts
@@ -357,7 +357,7 @@ async function renderAlerts(conn: duckdb.AsyncDuckDBConnection): Promise<void> {
     const entitiesHtml = entityArr.map(e => {
       const mmsi = VESSEL_MMSI[e];
       return mmsi
-        ? `${e} <a href="/analysis/?mmsi=${mmsi}" style="color:var(--accent);font-size:10px;text-decoration:none" title="View vessel risk profile">→ profile</a>`
+        ? `${e} <a href="/analysis/?mmsi=${mmsi}" style="color:var(--accent);font-size:10px;text-decoration:none" title="View analytics">→ analytics</a>`
         : e;
     }).join(", ");
     const ts = new Date(Number(r.timestamp_ms)).toISOString().replace("T", " ").slice(0, 19) + " UTC";
@@ -396,7 +396,7 @@ async function renderAlerts(conn: duckdb.AsyncDuckDBConnection): Promise<void> {
       const vesselLink = entityArr.find(e => VESSEL_MMSI[e])
         ? (() => {
             const e = entityArr.find(e => VESSEL_MMSI[e])!;
-            return ` <a href="/analysis/?mmsi=${VESSEL_MMSI[e]}" style="color:var(--accent);font-weight:600;text-decoration:none">View ${e} vessel risk profile →</a>`;
+            return ` <a href="/analysis/?mmsi=${VESSEL_MMSI[e]}" style="color:var(--accent);font-weight:600;text-decoration:none">View ${e} analytics →</a>`;
           })()
         : "";
 

--- a/docs/ref-architecture.md
+++ b/docs/ref-architecture.md
@@ -34,10 +34,10 @@ edgesentry/
 [documaris](https://github.com/edgesentry/documaris) is the sister product for port call documentation. Both products operate on the **same vessel entity (MMSI)**.
 
 ```
-clarus (vessel risk intelligence)      documaris (port call documentation)
-─────────────────────────────────      ───────────────────────────────────
-AIS gaps · STS transfers               FAL Form 1 · BWM certificate check
-Behavioural risk score                 Compliance alerts · Audit record
+clarus (physical port safety)          documaris (port call documentation)
+─────────────────────────────          ───────────────────────────────────
+Near-miss detection · Physics alerts   FAL Form 1 · BWM certificate check
+Tamper-proof audit records             Compliance alerts · Audit record
 https://clarus.edgesentry.io           https://documaris.pages.dev
          │                                       │
          └──────────── same vessel (MMSI) ───────┘
@@ -67,7 +67,7 @@ Pages includes **Cloudflare Pages Functions** (`analytics/functions/`) — edge 
 
 | Path | Entry point | Purpose |
 |------|-------------|---------|
-| `/` | `index.html` / `app.ts` | Risk Intelligence — vessel scores + alerts |
+| `/` | `index.html` / `app.ts` | Analytics — vessel scores (CAP Vista dual-use scenario) |
 | `/live` | `live.html` / `live.ts` | Operations Monitor — live heartbeats |
 | `/audit` | `audit.html` | Audit chain verification |
 | `/analysis/` | `analysis/index.html` | Deep-dive analysis |
@@ -117,7 +117,7 @@ Three public Cloudflare R2 buckets (see [ref-r2-data-layout.md](ref-r2-data-layo
 | Bucket | Binding | Written by | Read by |
 |--------|---------|-----------|---------|
 | `clarus-dev-public-raw` | `CLARUS_DEV_PUBLIC_RAW` | Edge daemon | `/live` Operations Monitor |
-| `clarus-dev-public-analytics` | `CLARUS_DEV_PUBLIC_ANALYTICS` | maridb pipelines | `/` Risk Intelligence |
+| `clarus-dev-public-analytics` | `CLARUS_DEV_PUBLIC_ANALYTICS` | edgesentry-rs pipelines | `/` Analytics |
 | `clarus-dev-public-audit` | `CLARUS_DEV_PUBLIC_AUDIT` | Edge daemon | `/audit` chain verification |
 
 Object format: **Parquet** (raw + analytics), **JSONL** (audit chain).  

--- a/docs/ref-architecture.md
+++ b/docs/ref-architecture.md
@@ -34,8 +34,8 @@ edgesentry/
 [documaris](https://github.com/edgesentry/documaris) is the sister product for port call documentation. Both products operate on the **same vessel entity (MMSI)**.
 
 ```
-clarus (physical port safety)          documaris (port call documentation)
-─────────────────────────────          ───────────────────────────────────
+clarus (safety monitoring)             documaris (port call documentation)
+──────────────────────────             ───────────────────────────────────
 Near-miss detection · Physics alerts   FAL Form 1 · BWM certificate check
 Tamper-proof audit records             Compliance alerts · Audit record
 https://clarus.edgesentry.io           https://documaris.pages.dev

--- a/docs/roadmap/core-poc.md
+++ b/docs/roadmap/core-poc.md
@@ -160,7 +160,7 @@ Goal: `RiskEvent` → natural-language explanation with verifiable regulation ci
 
 ### Week 5: Browser demo (due: 1 June)
 
-Goal: end-to-end screen-recordable demo showing Flow 1 (live alerts) → Flow 2 (vessel risk scorecard).
+Goal: end-to-end screen-recordable demo showing Flow 1 (live alerts) → Flow 2 (analytics).
 
 **Implemented** ([PR #52](https://github.com/edgesentry/clarus/pull/52), merged 2026-05-02):
 

--- a/docs/ui-personas.md
+++ b/docs/ui-personas.md
@@ -57,12 +57,11 @@ Singapore's MOM WSH penalties have tightened. P&I claims after serious incidents
 
 1. Opens `/live` — watches alert table showing rule, severity, evidence quality, confidence score
 2. Understands: "if this accumulates monthly, I can calculate a near-miss frequency"
-3. Clicks `RESTRICTED_ZONE_APPROACH` alert → sees "View V-001 vessel risk profile →"
-4. Navigates to `/` Risk Intelligence — MV Fortune Star auto-selected
-5. Reads behavioral score 74.3/100, sees AIS gaps, STS transfers, sanctions proximity
-6. **Premium Impact section**: Traditional $180,000 → With EdgeSentry $340,000 (+89%)
-7. Sees "Blind spot" in the traditional column for all behavioral signals
-8. Understands: "the $160k gap is exactly what I'm missing in my current underwriting"
+3. Clicks `RESTRICTED_ZONE_APPROACH` alert → reads physics evidence: clearance 3.2m vs 5m required, confidence CERTIFIED
+4. Sees LLM explanation citing MPA Port Safety Circular 2024-07, section 3.1
+5. Navigates to `/audit` — confirms hash chain is intact, record cannot be edited
+6. **Premium Impact**: tamper-proof near-miss frequency record → actuarially defensible premium discount
+7. Understands: "two years of this data and I can compute a near-miss rate. No one has brought me this before."
 
 ### The moment her goal is achieved
 
@@ -140,8 +139,8 @@ In most cases the operator asserts the system was active. The only evidence avai
 | `/live` site status + drift chart | ✓ Sees monitoring is active | — | ✓ Sees calibration quality | — |
 | `/live` alert table with evidence quality | ✓ Reads regulation citation | ✓ Sees structured data fields | ✓ Confirms physics-based firing | — |
 | `/live` LLM explanation | ✓ Reads plain-language alert | — | ✓ Understands physics basis | — |
-| `/` vessel risk scorecard | — | ✓ Sees behavioral indicators | — | — |
-| `/` premium impact (Blind spot → $340k) | — | ✓ **Core feature** | — | — |
+| `/audit` near-miss frequency record | — | ✓ Sees structured tamper-proof data | — | — |
+| `/live` physics evidence + LLM citation | — | ✓ **Core feature** | — | — |
 | `/audit` chain verification *(coming: #55)* | ✓ Understands tamper-evidence | ✓ Confirms operator cannot edit | — | ✓ **Core feature** |
 
 ---

--- a/docs/ui-personas.md
+++ b/docs/ui-personas.md
@@ -1,5 +1,7 @@
 # clarus — User Personas
 
+clarus is a profile-switchable safety monitoring platform. The personas below use the **`sg-port-safety` profile** as the primary example — the same engine and audit chain apply to any domain (maritime security, construction, logistics) via profile swap.
+
 There are four users. Each has a different problem. clarus does not solve "we have no records." It solves "our records are not trusted."
 
 ---


### PR DESCRIPTION
## Summary

Removes all "vessel risk intelligence" / arktrace-domain framing from clarus docs and web app. Corrects the positioning: clarus is a **profile-switchable safety monitoring platform** — port safety (`sg-port-safety/`) is the primary PIER71 demo use case, maritime security (`sg-maritime-security/`) is the CAP Vista dual-use case, and the same engine applies to other industries via profile swap.

Closes #83.

**Docs:**
- `README.md`: rewritten lead + profile table; label → "safety monitoring"
- `AGENTS.md`: description + profile table added; domain-agnostic engine clarified
- `docs/ref-architecture.md`: platform table label updated; `/` labelled as "Analytics (CAP Vista dual-use)"
- `docs/ui-personas.md`: intro notes sg-port-safety is one deployment profile; persona flows updated to use `/live` physics evidence + `/audit` chain

**Web app:**
- `analytics/index.html`: title + h1 → "clarus — Analytics"; nav reordered (Operations Monitor first)
- `analytics/live.html` + `audit.html`: nav "Risk Intelligence" → "Analytics"
- `analytics/live.ts`: "View vessel risk profile →" → "View analytics →"
- `analytics/app.ts`: comment updated

**Not changed:** analytics data fields (AIS gaps, sanctions distance etc.) — these serve the CAP Vista dual-use maritime security scenario. Data layer migration is a separate task.

## Acceptance criteria
- [x] No arktrace-domain content ("vessel risk intelligence", "AIS gaps · STS transfers", "Behavioural risk score") in docs or web app headers
- [x] README describes profile-switchable platform with port safety as primary demo
- [x] `docs/ref-architecture.md` platform table updated
- [x] `docs/ui-personas.md` notes sg-port-safety as one profile
- [ ] `/live` route demo verified locally (Operations Monitor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)