### PR TITLE
perf(admin): OPFS cache for /admin/live and /admin/audit

### DIFF
--- a/analytics/admin/audit.ts
+++ b/analytics/admin/audit.ts
@@ -1,5 +1,6 @@
 // EdgeSentry Audit Chain — audit.ts
 export {}; // make this a module so top-level await and const status don't conflict with globals
+import { getCachedAuditRecord, setCachedAuditRecord } from "./opfs-cache.js";
 
 interface AuditRecord {
   sequence: number;
@@ -37,9 +38,13 @@ async function fetchIndex(site: string | null): Promise<AuditIndex> {
 }
 
 async function fetchRecord(key: string): Promise<AuditRecord | null> {
+  const cached = await getCachedAuditRecord(key);
+  if (cached) return JSON.parse(cached) as AuditRecord;
   const resp = await fetch(`/data/audit/${key}`);
   if (!resp.ok) return null;
-  return resp.json();
+  const text = await resp.text();
+  await setCachedAuditRecord(key, text);
+  return JSON.parse(text) as AuditRecord;
 }
 
 // ── Chain verification ────────────────────────────────────────────────────────

--- a/analytics/admin/live.ts
+++ b/analytics/admin/live.ts
@@ -2,6 +2,7 @@
 
 import * as duckdb from "@duckdb/duckdb-wasm";
 import * as Plot from "@observablehq/plot";
+import { fetchParquetCached } from "./opfs-cache.js";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -175,9 +176,9 @@ async function loadParquetFiles(
   if (keys.length === 0) return false;
   const fnames: string[] = [];
   for (const [i, key] of keys.entries()) {
-    const resp = await fetch(`/data/raw/${key}`);
-    if (!resp.ok) continue;
-    await db.registerFileBuffer(`${tableName}_${i}.parquet`, new Uint8Array(await resp.arrayBuffer()));
+    const buf = await fetchParquetCached(`/data/raw/${key}`, key);
+    if (!buf) continue;
+    await db.registerFileBuffer(`${tableName}_${i}.parquet`, new Uint8Array(buf));
     fnames.push(`${tableName}_${i}.parquet`);
   }
   if (fnames.length === 0) return false;

--- a/analytics/admin/opfs-cache.test.ts
+++ b/analytics/admin/opfs-cache.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// We test the pure key-transformation helpers by re-implementing them inline,
+// since they are not exported.  The main value of these tests is to lock in the
+// file-naming contract so refactors don't silently break cache lookups.
+
+// Helpers mirrored from opfs-cache.ts (must stay in sync)
+function metaKey(key: string): string {
+  return key.replace(/\//g, "__") + ".meta.json";
+}
+function dataKey(key: string): string {
+  return key.replace(/\//g, "__") + ".bin";
+}
+function auditKey(key: string): string {
+  return "audit__" + key.replace(/\//g, "__") + ".json";
+}
+
+describe("key derivation", () => {
+  it("metaKey replaces slashes and appends .meta.json", () => {
+    expect(metaKey("sg-port-safety/2024-01-01/hb.parquet")).toBe(
+      "sg-port-safety__2024-01-01__hb.parquet.meta.json"
+    );
+  });
+
+  it("dataKey replaces slashes and appends .bin", () => {
+    expect(dataKey("sg-port-safety/2024-01-01/hb.parquet")).toBe(
+      "sg-port-safety__2024-01-01__hb.parquet.bin"
+    );
+  });
+
+  it("auditKey prefixes with audit__ and replaces slashes", () => {
+    expect(auditKey("sg-port-safety/rec-001.json")).toBe(
+      "audit__sg-port-safety__rec-001.json.json"
+    );
+  });
+
+  it("flat key (no slashes) passes through unchanged", () => {
+    expect(metaKey("hb.parquet")).toBe("hb.parquet.meta.json");
+    expect(dataKey("hb.parquet")).toBe("hb.parquet.bin");
+    expect(auditKey("rec.json")).toBe("audit__rec.json.json");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration-style test using a fake OPFS via navigator.storage stub
+// ---------------------------------------------------------------------------
+
+function makeOpfsStub() {
+  const files = new Map<string, Uint8Array | string>();
+
+  function makeFileHandle(name: string) {
+    return {
+      getFile: async () => ({
+        text: async () => {
+          const v = files.get(name);
+          if (v === undefined) throw new Error("not found");
+          return typeof v === "string" ? v : new TextDecoder().decode(v);
+        },
+        arrayBuffer: async () => {
+          const v = files.get(name);
+          if (v === undefined) throw new Error("not found");
+          return (v as Uint8Array).buffer;
+        },
+      }),
+      createWritable: async () => {
+        const chunks: (string | ArrayBuffer)[] = [];
+        return {
+          write: async (chunk: string | ArrayBuffer) => chunks.push(chunk),
+          close: async () => {
+            if (typeof chunks[0] === "string") {
+              files.set(name, chunks.join(""));
+            } else {
+              files.set(name, new Uint8Array(chunks[0] as ArrayBuffer));
+            }
+          },
+        };
+      },
+    };
+  }
+
+  const dir = {
+    getFileHandle: async (name: string, opts?: { create?: boolean }) => {
+      if (!opts?.create && !files.has(name) && !name.startsWith("__opfs_test__")) {
+        const err = new DOMException("not found", "NotFoundError");
+        throw err;
+      }
+      return makeFileHandle(name);
+    },
+    removeEntry: async (name: string) => { files.delete(name); },
+  };
+
+  return {
+    files,
+    storage: {
+      getDirectory: async () => ({
+        getDirectoryHandle: async (_name: string, _opts?: { create?: boolean }) => dir,
+      }),
+    },
+  };
+}
+
+describe("getCachedParquet / setCachedParquet", async () => {
+  beforeEach(() => {
+    // Reset the module-level availability cache between tests
+    vi.resetModules();
+  });
+
+  it("returns null on cache miss", async () => {
+    const stub = makeOpfsStub();
+    vi.stubGlobal("navigator", { storage: stub.storage });
+
+    const { getCachedParquet } = await import("./opfs-cache.js");
+    const result = await getCachedParquet("missing-key");
+    expect(result).toBeNull();
+  });
+
+  it("round-trips an ArrayBuffer through the cache", async () => {
+    const stub = makeOpfsStub();
+    vi.stubGlobal("navigator", { storage: stub.storage });
+
+    const { getCachedParquet, setCachedParquet } = await import("./opfs-cache.js");
+    const original = new Uint8Array([1, 2, 3, 4]).buffer;
+
+    await setCachedParquet("test/hb.parquet", original);
+    const retrieved = await getCachedParquet("test/hb.parquet");
+
+    expect(retrieved).not.toBeNull();
+    expect(new Uint8Array(retrieved!)).toEqual(new Uint8Array([1, 2, 3, 4]));
+  });
+
+  it("returns null when cache is stale (> 1h)", async () => {
+    const stub = makeOpfsStub();
+    vi.stubGlobal("navigator", { storage: stub.storage });
+
+    const PARQUET_TTL_MS = 60 * 60 * 1000;
+    const oldTs = Date.now() - PARQUET_TTL_MS - 1000;
+
+    // Manually insert stale metadata
+    const metaName = "test__stale.parquet.meta.json";
+    const dataName = "test__stale.parquet.bin";
+    stub.files.set(metaName, JSON.stringify({ ts: oldTs }));
+    stub.files.set(dataName, new Uint8Array([9]));
+
+    const { getCachedParquet } = await import("./opfs-cache.js");
+    const result = await getCachedParquet("test/stale.parquet");
+    expect(result).toBeNull();
+  });
+});
+
+describe("getCachedAuditRecord / setCachedAuditRecord", async () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("returns null on cache miss", async () => {
+    const stub = makeOpfsStub();
+    vi.stubGlobal("navigator", { storage: stub.storage });
+
+    const { getCachedAuditRecord } = await import("./opfs-cache.js");
+    expect(await getCachedAuditRecord("no-such-record")).toBeNull();
+  });
+
+  it("round-trips a JSON string through the audit cache", async () => {
+    const stub = makeOpfsStub();
+    vi.stubGlobal("navigator", { storage: stub.storage });
+
+    const { getCachedAuditRecord, setCachedAuditRecord } = await import("./opfs-cache.js");
+    const payload = JSON.stringify({ sequence: 1, record_hash_hex: "abc" });
+
+    await setCachedAuditRecord("site/rec-001.json", payload);
+    const retrieved = await getCachedAuditRecord("site/rec-001.json");
+
+    expect(retrieved).toBe(payload);
+  });
+
+  it("audit cache has no TTL — serves stale content indefinitely", async () => {
+    const stub = makeOpfsStub();
+    vi.stubGlobal("navigator", { storage: stub.storage });
+
+    const { getCachedAuditRecord, setCachedAuditRecord } = await import("./opfs-cache.js");
+    const payload = JSON.stringify({ sequence: 42 });
+    await setCachedAuditRecord("site/old-rec.json", payload);
+
+    // Even after a long time has passed (simulated by not modifying the data),
+    // audit records should still be returned.
+    const retrieved = await getCachedAuditRecord("site/old-rec.json");
+    expect(retrieved).toBe(payload);
+  });
+});

--- a/analytics/admin/opfs-cache.ts
+++ b/analytics/admin/opfs-cache.ts
@@ -1,0 +1,126 @@
+/**
+ * OPFS caching helpers for admin page Parquet and audit record fetches.
+ *
+ * Strategy:
+ *   - Parquet files (heartbeats, alert chains): TTL-based cache (default 1h).
+ *     Re-fetch when stale; serve from OPFS when fresh.
+ *   - Audit records (WORM / Object Lock): cache indefinitely — they are
+ *     immutable by design.
+ *
+ * Falls back to direct fetch if OPFS is unavailable (Safari Private, Firefox
+ * without storage permission, etc.).
+ */
+
+const DIR_NAME = "clarus-admin-cache";
+const PARQUET_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+let _opfsAvailable: boolean | null = null;
+
+async function opfsAvailable(): Promise<boolean> {
+  if (_opfsAvailable !== null) return _opfsAvailable;
+  try {
+    const root = await navigator.storage.getDirectory();
+    const dir = await root.getDirectoryHandle(DIR_NAME, { create: true });
+    const testName = "__opfs_test__";
+    const fh = await dir.getFileHandle(testName, { create: true });
+    const w = await fh.createWritable();
+    await w.write("1");
+    await w.close();
+    await dir.removeEntry(testName);
+    _opfsAvailable = true;
+  } catch {
+    _opfsAvailable = false;
+  }
+  return _opfsAvailable;
+}
+
+async function cacheDir(): Promise<FileSystemDirectoryHandle> {
+  const root = await navigator.storage.getDirectory();
+  return root.getDirectoryHandle(DIR_NAME, { create: true });
+}
+
+function metaKey(key: string): string {
+  return key.replace(/\//g, "__") + ".meta.json";
+}
+
+function dataKey(key: string): string {
+  return key.replace(/\//g, "__") + ".bin";
+}
+
+// ---------------------------------------------------------------------------
+// Parquet cache (TTL-based)
+// ---------------------------------------------------------------------------
+
+export async function getCachedParquet(key: string): Promise<ArrayBuffer | null> {
+  if (!(await opfsAvailable())) return null;
+  try {
+    const dir = await cacheDir();
+    const metaHandle = await dir.getFileHandle(metaKey(key));
+    const metaText = await (await metaHandle.getFile()).text();
+    const { ts } = JSON.parse(metaText) as { ts: number };
+    if (Date.now() - ts > PARQUET_TTL_MS) return null;
+
+    const dataHandle = await dir.getFileHandle(dataKey(key));
+    return (await dataHandle.getFile()).arrayBuffer();
+  } catch {
+    return null;
+  }
+}
+
+export async function setCachedParquet(key: string, buf: ArrayBuffer): Promise<void> {
+  if (!(await opfsAvailable())) return;
+  try {
+    const dir = await cacheDir();
+
+    const metaHandle = await dir.getFileHandle(metaKey(key), { create: true });
+    const mw = await metaHandle.createWritable();
+    await mw.write(JSON.stringify({ ts: Date.now() }));
+    await mw.close();
+
+    const dataHandle = await dir.getFileHandle(dataKey(key), { create: true });
+    const dw = await dataHandle.createWritable();
+    await dw.write(buf);
+    await dw.close();
+  } catch { /* best-effort */ }
+}
+
+// ---------------------------------------------------------------------------
+// Audit record cache (immutable / indefinite)
+// ---------------------------------------------------------------------------
+
+export async function getCachedAuditRecord(key: string): Promise<string | null> {
+  if (!(await opfsAvailable())) return null;
+  try {
+    const dir = await cacheDir();
+    const fh = await dir.getFileHandle("audit__" + key.replace(/\//g, "__") + ".json");
+    return (await fh.getFile()).text();
+  } catch {
+    return null;
+  }
+}
+
+export async function setCachedAuditRecord(key: string, text: string): Promise<void> {
+  if (!(await opfsAvailable())) return;
+  try {
+    const dir = await cacheDir();
+    const fh = await dir.getFileHandle("audit__" + key.replace(/\//g, "__") + ".json", { create: true });
+    const w = await fh.createWritable();
+    await w.write(text);
+    await w.close();
+  } catch { /* best-effort */ }
+}
+
+// ---------------------------------------------------------------------------
+// Convenience: fetch with OPFS Parquet cache
+// ---------------------------------------------------------------------------
+
+export async function fetchParquetCached(url: string, cacheKey: string): Promise<ArrayBuffer | null> {
+  const cached = await getCachedParquet(cacheKey);
+  if (cached) return cached;
+
+  const resp = await fetch(url);
+  if (!resp.ok) return null;
+  const buf = await resp.arrayBuffer();
+  await setCachedParquet(cacheKey, buf);
+  return buf;
+}


### PR DESCRIPTION
Closes #88

## Summary

- New `admin/opfs-cache.ts` — TTL-based OPFS cache for Parquet files (1h) and indefinite cache for immutable WORM audit records
- `admin/live.ts` — `loadParquetFiles()` replaced bare `fetch` with `fetchParquetCached`; on repeat visits all Parquet data is served from OPFS without touching R2
- `admin/audit.ts` — `fetchRecord()` now checks the audit OPFS cache first; audit records are never re-fetched once cached (they are WORM / Object Lock immutable)
- Graceful fallback to direct fetch if OPFS is unavailable (Safari Private, Firefox without storage permission)
- 10 unit tests in `admin/opfs-cache.test.ts` covering key derivation, round-trip read/write, TTL expiry (Parquet), and no-TTL behaviour (audit)

## Test plan

- [x] `npm test admin/opfs-cache.test.ts` — 10/10 pass
- [x] `npm run build` — clean build, `opfs-cache` emitted as a separate chunk
- [ ] Verify locally: first load of `/admin/live` warms OPFS; reload skips network requests (check DevTools → Application → Storage → OPFS)
- [ ] Verify locally: first load of `/admin/audit` fetches records; reload serves from OPFS instantly

🤖 Generated with [Claude Code](https://claude.com/claude-code)