### PR TITLE
chore(edge): add restart.sh + config.env.example for BCA profile

### DIFF
--- a/edge/restart.sh
+++ b/edge/restart.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Restart clarus-edge: kill any running instance, wipe local DB, start fresh.
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+echo "[restart.sh] Stopping existing clarus-edge..."
+pkill -f clarus-edge 2>/dev/null && echo "[restart.sh] Killed." || echo "[restart.sh] Not running."
+sleep 1
+
+echo "[restart.sh] Clearing local DuckDB..."
+rm -f clarus_edge.db clarus_edge.db-shm clarus_edge.db-wal
+
+exec bash run.sh "$@"


### PR DESCRIPTION
- `restart.sh`: stops any running clarus-edge, wipes local DuckDB, execs `run.sh`
- `config.env` (gitignored): pre-configured for `MCH-OUTLET-042` / `sg-bca-greenmark` — copy from `config.env.example`

Usage:
```bash
cd edge
bash restart.sh   # kill → wipe DB → rebuild → start
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)