### PR TITLE
fix(zkp): clippy — inner doc comments, move decode_attestation to test scope

### DIFF
--- a/edge/src/db.rs
+++ b/edge/src/db.rs
@@ -8,7 +8,6 @@ use anyhow::Result;
 use duckdb::{params, Connection};
 use edgesentry_audit::AuditRecord;
 use edgesentry_evaluate::RiskEvent;
-use hex;
 use serde::{Deserialize, Serialize};
 
 // ── Schema ────────────────────────────────────────────────────────────────────

--- a/edge/src/storage.rs
+++ b/edge/src/storage.rs
@@ -68,7 +68,7 @@ impl Storage {
     async fn put(&self, bucket: &str, key: &str, data: Bytes) -> Result<()> {
         match self.backend.as_str() {
             "s3" | "minio" => {
-                let store = if bucket == &self.audit_bucket {
+                let store = if bucket == self.audit_bucket {
                     self.s3_audit.as_ref().unwrap()
                 } else {
                     self.s3_analytics.as_ref().unwrap()

--- a/edge/src/zkp/green_mark.rs
+++ b/edge/src/zkp/green_mark.rs
@@ -1,20 +1,20 @@
-/// BCA Green Mark 2021 — ZKP computation layer.
-///
-/// This module implements [`edgesentry_zkp::ZkProgram`] for the BCA Green Mark
-/// energy compliance calculation.  The prover takes raw sensor readings as
-/// private input and commits only the pass/fail result and the computed score —
-/// raw energy, occupancy, and area data never leave the edge device.
-///
-/// # Certification levels (Section 4 — Existing Buildings)
-///
-/// | Level    | EUI threshold (kWh/m²/year) |
-/// |----------|-----------------------------|
-/// | Certified | ≤ 135                      |
-/// | Gold      | ≤ 115                      |
-/// | GoldPlus  | ≤  95                      |
-/// | Platinum  | ≤  75                      |
-///
-/// References: BCA Green Mark 2021, SS 553:2016, BCA Energy Efficiency Act 2012.
+//! BCA Green Mark 2021 — ZKP computation layer.
+//!
+//! This module implements [`edgesentry_zkp::ZkProgram`] for the BCA Green Mark
+//! energy compliance calculation.  The prover takes raw sensor readings as
+//! private input and commits only the pass/fail result and the computed score —
+//! raw energy, occupancy, and area data never leave the edge device.
+//!
+//! # Certification levels (Section 4 — Existing Buildings)
+//!
+//! | Level    | EUI threshold (kWh/m²/year) |
+//! |----------|-----------------------------|
+//! | Certified | ≤ 135                      |
+//! | Gold      | ≤ 115                      |
+//! | GoldPlus  | ≤  95                      |
+//! | Platinum  | ≤  75                      |
+//!
+//! References: BCA Green Mark 2021, SS 553:2016, BCA Energy Efficiency Act 2012.
 
 use serde::{Deserialize, Serialize};
 
@@ -166,17 +166,16 @@ impl ZkProgram for GreenMarkProgram {
     }
 }
 
-/// Decode the public attestation from a proof's `public_values` field.
-pub fn decode_attestation(proof: &ZkProof) -> Result<GreenMarkAttestation, ZkError> {
-    let bytes = proof
-        .decode_public_values()
-        .map_err(|e| ZkError::InvalidProof(e.to_string()))?;
-    serde_json::from_slice(&bytes).map_err(|e| ZkError::InvalidProof(e.to_string()))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn decode_attestation(proof: &ZkProof) -> Result<GreenMarkAttestation, ZkError> {
+        let bytes = proof
+            .decode_public_values()
+            .map_err(|e| ZkError::InvalidProof(e.to_string()))?;
+        serde_json::from_slice(&bytes).map_err(|e| ZkError::InvalidProof(e.to_string()))
+    }
 
     fn inputs(eui: f32, cop: f32, lpd: f32) -> GreenMarkInputs {
         GreenMarkInputs {

--- a/edge/src/zkp/mod.rs
+++ b/edge/src/zkp/mod.rs
@@ -1,5 +1,5 @@
 pub mod green_mark;
 pub mod ot_integrity;
 
-pub use green_mark::{GreenMarkProgram, GreenMarkInputs, GreenMarkAttestation, decode_attestation};
-pub use ot_integrity::{OtIntegrityProgram, OtIntegrityAttestation, sim_inputs as ot_sim_inputs};
+pub use green_mark::{GreenMarkProgram, GreenMarkInputs};
+pub use ot_integrity::{OtIntegrityProgram, sim_inputs as ot_sim_inputs};

--- a/edge/src/zkp/ot_integrity.rs
+++ b/edge/src/zkp/ot_integrity.rs
@@ -1,32 +1,32 @@
-/// OT/IT Cybersecurity Integrity — ZKP computation layer.
-///
-/// Addresses PIER71-02: "Managing Cybersecurity Risks and Incidences"
-/// (IACS UR E26/27, IMO MSC-FAL.1/Circ.3).
-///
-/// An OT device (PLC, navigation system, engine control unit) measures the
-/// SHA-256 hash of every running binary and configuration file, then proves
-/// that all measured hashes appear in a pre-approved allowlist — without
-/// revealing *which* specific software is running (competitive sensitivity).
-///
-/// # What is proved (public)
-///
-/// - `device_id`: which OT device was attested
-/// - `all_authorized`: true iff every measured component is on the allowlist
-/// - `unauthorized_count`: number of components NOT on the allowlist (0 = clean)
-/// - `component_count`: total number of components measured
-/// - `allowlist_version`: version/hash of the approved allowlist used
-/// - `attested_at_ms`: attestation timestamp
-///
-/// # What stays private
-///
-/// - The individual component hashes (reveals software stack to competitors)
-/// - The full allowlist contents (internal IP)
-///
-/// # Regulatory alignment
-///
-/// - IACS UR E26: "software integrity verification for OT systems"
-/// - IACS UR E27: "cyber-resilient systems — authorised software control"
-/// - IMO MSC-FAL.1/Circ.3: "verify integrity of operational technology"
+//! OT/IT Cybersecurity Integrity — ZKP computation layer.
+//!
+//! Addresses PIER71-02: "Managing Cybersecurity Risks and Incidences"
+//! (IACS UR E26/27, IMO MSC-FAL.1/Circ.3).
+//!
+//! An OT device (PLC, navigation system, engine control unit) measures the
+//! SHA-256 hash of every running binary and configuration file, then proves
+//! that all measured hashes appear in a pre-approved allowlist — without
+//! revealing *which* specific software is running (competitive sensitivity).
+//!
+//! # What is proved (public)
+//!
+//! - `device_id`: which OT device was attested
+//! - `all_authorized`: true iff every measured component is on the allowlist
+//! - `unauthorized_count`: number of components NOT on the allowlist (0 = clean)
+//! - `component_count`: total number of components measured
+//! - `allowlist_version`: version/hash of the approved allowlist used
+//! - `attested_at_ms`: attestation timestamp
+//!
+//! # What stays private
+//!
+//! - The individual component hashes (reveals software stack to competitors)
+//! - The full allowlist contents (internal IP)
+//!
+//! # Regulatory alignment
+//!
+//! - IACS UR E26: "software integrity verification for OT systems"
+//! - IACS UR E27: "cyber-resilient systems — authorised software control"
+//! - IMO MSC-FAL.1/Circ.3: "verify integrity of operational technology"
 
 use serde::{Deserialize, Serialize};
 
@@ -164,14 +164,6 @@ impl ZkProgram for OtIntegrityProgram {
     }
 }
 
-/// Decode the public attestation from a proof's `public_values` field.
-pub fn decode_attestation(proof: &ZkProof) -> Result<OtIntegrityAttestation, ZkError> {
-    let bytes = proof
-        .decode_public_values()
-        .map_err(|e| ZkError::InvalidProof(e.to_string()))?;
-    serde_json::from_slice(&bytes).map_err(|e| ZkError::InvalidProof(e.to_string()))
-}
-
 // ── Simulation helper ──────────────────────────────────────────────────────────
 
 /// Generate deterministic OT integrity inputs for the demo/simulation scenario.
@@ -203,6 +195,13 @@ pub fn sim_inputs(device_id: &str, cycle: u64, now_ms: u64) -> OtIntegrityInputs
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn decode_attestation(proof: &ZkProof) -> Result<OtIntegrityAttestation, ZkError> {
+        let bytes = proof
+            .decode_public_values()
+            .map_err(|e| ZkError::InvalidProof(e.to_string()))?;
+        serde_json::from_slice(&bytes).map_err(|e| ZkError::InvalidProof(e.to_string()))
+    }
 
     fn inputs_clean(device: &str) -> OtIntegrityInputs {
         let hashes: Vec<String> = (0..5u8)


### PR DESCRIPTION
## Summary

- Convert `///` to `//!` in `green_mark.rs` and `ot_integrity.rs` (module-level doc comments)
- Move `decode_attestation` helpers inside `#[cfg(test)]` — only used in tests within each module
- Fix `op_ref` lint in `storage.rs` (`bucket == &self.audit_bucket` → `bucket == self.audit_bucket`)
- Remove bare `use hex;` in `db.rs` (single-component-path-imports lint)

## Test plan

- [x] `cargo test` — 41/41 pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)