### PR TITLE
fix(ci): upgrade Node 22 → 24 in deploy workflow

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
           cache-dependency-path: analytics/package-lock.json
 


### PR DESCRIPTION
## Problem

`npm ci` fails on the deploy workflow with:

```
Missing: @emnapi/core@1.10.0 from lock file
Missing: @emnapi/runtime@1.10.0 from lock file
```

`@scalar/api-reference` resolves optional native bindings (`@emnapi/core`, `@emnapi/runtime`) differently on Node 22 vs Node 24. The `package-lock.json` is generated locally with Node 24 / npm 11 and is incompatible with Node 22's resolution.

## Fix

Upgrade `node-version: 22 → 24` in `deploy-app.yml` to match the local development environment.

## Test plan

- [ ] Deploy workflow passes `npm ci`

🤖 Generated with [Claude Code](https://claude.com/claude-code)