### PR TITLE
fix(api-docs): relax COEP for /api-docs — fix broken Scalar layout

### DIFF
--- a/analytics/public/_headers
+++ b/analytics/public/_headers
@@ -1,3 +1,8 @@
 /*
   Cross-Origin-Opener-Policy: same-origin
   Cross-Origin-Embedder-Policy: require-corp
+
+# /api-docs uses Scalar which loads inline assets — relax COEP for this page only
+/api-docs
+  Cross-Origin-Opener-Policy: same-origin
+  Cross-Origin-Embedder-Policy: unsafe-none


### PR DESCRIPTION
## Problem

`Cross-Origin-Embedder-Policy: require-corp` is set globally for SharedArrayBuffer support (DuckDB WASM). This blocks Scalar's internal asset loading on `/api-docs`, breaking the UI layout.

## Fix

Override COEP to `unsafe-none` for `/api-docs` only via `public/_headers`. All other pages keep `require-corp`.

```
/api-docs
  Cross-Origin-Opener-Policy: same-origin
  Cross-Origin-Embedder-Policy: unsafe-none
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)