### PR TITLE
fix(headers): set COEP per-page instead of globally — fix /api-docs Scalar

### DIFF
--- a/analytics/public/_headers
+++ b/analytics/public/_headers
@@ -1,8 +1,20 @@
+# COOP is safe to apply globally
 /*
   Cross-Origin-Opener-Policy: same-origin
+
+# COEP require-corp is required only for pages that use DuckDB WASM (SharedArrayBuffer).
+# Applying it globally breaks /api-docs (Scalar), so it is set per-page instead.
+/
   Cross-Origin-Embedder-Policy: require-corp
 
-# /api-docs uses Scalar which loads inline assets — relax COEP for this page only
-/api-docs
-  Cross-Origin-Opener-Policy: same-origin
-  Cross-Origin-Embedder-Policy: unsafe-none
+/maritime/analytics/
+  Cross-Origin-Embedder-Policy: require-corp
+
+/admin/live
+  Cross-Origin-Embedder-Policy: require-corp
+
+/admin/status
+  Cross-Origin-Embedder-Policy: require-corp
+
+/admin/audit
+  Cross-Origin-Embedder-Policy: require-corp


### PR DESCRIPTION
## Problem

`_headers` had `Cross-Origin-Embedder-Policy: require-corp` on `/*` and `unsafe-none` on `/api-docs`. Cloudflare Pages sends **both** headers additively, so the browser received two conflicting COEP values and used `require-corp`, still blocking Scalar.

## Fix

Remove COEP from the global `/*` rule. Apply `require-corp` only to the pages that actually use DuckDB WASM (SharedArrayBuffer):

- `/` — main analytics
- `/maritime/analytics/` — maritime analytics
- `/admin/live` — operations monitor
- `/admin/status` — pipeline status
- `/admin/audit` — audit chain

`/api-docs` gets no COEP header → Scalar renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)