### PR TITLE
fix(docs-deploy): upgrade upload-pages-artifact v3→v5 — fix action pinning policy

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -39,10 +39,10 @@ jobs:
       - name: Build
         run: mkdocs build --strict
 
-      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
         with:
           path: site/
 
       - name: Deploy
         id: deploy
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0


### PR DESCRIPTION
## Problem

`actions/upload-pages-artifact@v3` internally calls `actions/upload-artifact@v4` without a full SHA, violating the repo's action policy:

> all actions must be pinned to a full-length commit SHA

## Fix

Upgrade to v5.0.0 for both actions:
- `upload-pages-artifact`: `56afc609...` (v3) → `fc324d35...` (v5.0.0)
- `deploy-pages`: `d6db9016...` (v4) → `cd2ce8fc...` (v5.0.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)