### PR TITLE
refactor: lift BCA attestation to top-level, replace zkp-latest with compliance-latest

### DIFF
--- a/analytics/functions/api/_zk-fetch.ts
+++ b/analytics/functions/api/_zk-fetch.ts
@@ -3,18 +3,24 @@ import type { AuditRecord, Env, R2BucketMinimal } from "./_zk-types.js";
 interface RunEntry { run_id: string; last_seq: number }
 
 /**
- * Fetch the most recent audit record containing a zk_proof for the given site.
+ * Fetch the most recent audit record containing a compliance attestation
+ * (top-level `attestation` field) or a legacy `zk_proof` for the given site.
  *
  * Strategy:
- * 1. Read zkp-latest/{site}.json pointer (written on each proof cycle, strongly consistent).
- * 2. Fallback: scan audit chain key listing for the newest run.
+ * 1. Read compliance-latest/{site}.json pointer (written on each BCA cycle).
+ * 2. Fallback: read zkp-latest/{site}.json pointer (legacy format).
+ * 3. Fallback: scan audit chain key listing for the newest run.
  *
  * Scans at most 10 records from the tail of the newest run.
  */
 export async function fetchLatestZkRecord(siteId: string, env: Env): Promise<AuditRecord | null> {
-  const ptr = await env.CLARUS_DEV_PUBLIC_RAW.get(`zkp-latest/${siteId}.json`);
-  if (ptr) {
-    const { run_id, last_seq } = JSON.parse(await ptr.text()) as { run_id: string; last_seq: number };
+  // Try compliance-latest first (new format), then zkp-latest (legacy)
+  const ptrObj =
+    await env.CLARUS_DEV_PUBLIC_RAW.get(`compliance-latest/${siteId}.json`) ??
+    await env.CLARUS_DEV_PUBLIC_RAW.get(`zkp-latest/${siteId}.json`);
+
+  if (ptrObj) {
+    const { run_id, last_seq } = JSON.parse(await ptrObj.text()) as { run_id: string; last_seq: number };
     if (run_id != null && last_seq != null) {
       const record = await scanRun(siteId, run_id, last_seq, env);
       if (record) return record;
@@ -46,7 +52,7 @@ async function scanRun(siteId: string, runId: string, lastSeq: number, env: Env)
     const obj = await env.CLARUS_DEV_PUBLIC_AUDIT.get(key);
     if (!obj) continue;
     const record = JSON.parse(await obj.text()) as AuditRecord;
-    if (record.zk_proof) return record;
+    if (record.attestation || record.zk_proof) return record;
   }
   return null;
 }

--- a/analytics/functions/api/_zk-types.ts
+++ b/analytics/functions/api/_zk-types.ts
@@ -23,10 +23,11 @@ export interface GreenMarkAttestation {
 }
 
 export interface AuditRecord {
-  sequence:        number;
-  timestamp_ms:    number;
+  sequence:         number;
+  timestamp_ms:     number;
   record_hash_hex?: string;
-  zk_proof?:       ZkProof;
+  attestation?:     GreenMarkAttestation; // top-level BCA compliance result (new format)
+  zk_proof?:        ZkProof;              // optional ZKP proof for future SP1 / B2B path
 }
 
 // Minimal R2 surface used by these functions — avoids @cloudflare/workers-types

--- a/analytics/functions/api/verify-raw.test.ts
+++ b/analytics/functions/api/verify-raw.test.ts
@@ -30,7 +30,9 @@ function makeEnv(ptrBody: { run_id: string; last_seq: number } | null, auditObje
   return {
     CLARUS_DEV_PUBLIC_RAW: {
       get: vi.fn(async (key: string) => {
-        if (key.startsWith("zkp-latest/") && ptrBody) return { text: async () => JSON.stringify(ptrBody) };
+        if ((key.startsWith("compliance-latest/") || key.startsWith("zkp-latest/")) && ptrBody) {
+          return { text: async () => JSON.stringify(ptrBody) };
+        }
         return null;
       }),
     } as unknown as R2BucketMinimal,

--- a/analytics/functions/api/verify.test.ts
+++ b/analytics/functions/api/verify.test.ts
@@ -23,35 +23,41 @@ function makeAttestation(overrides: Partial<GreenMarkAttestation> = {}): GreenMa
   };
 }
 
-function makeProof(att: GreenMarkAttestation, tamper = false): ZkProof {
+// New format: top-level attestation field
+function makeRecord(seq: number, att?: GreenMarkAttestation): AuditRecord {
+  return {
+    sequence:        seq,
+    timestamp_ms:    1_778_000_000_000 + seq * 1000,
+    record_hash_hex: "a".repeat(64),
+    ...(att ? { attestation: att } : {}),
+  };
+}
+
+// Legacy format: zk_proof with public_values
+function makeLegacyRecord(seq: number, att?: GreenMarkAttestation, tamper = false): AuditRecord {
+  if (!att) return { sequence: seq, timestamp_ms: 1_778_000_000_000 };
   const json     = JSON.stringify(att);
   const pubBytes = new TextEncoder().encode(json);
   const hash     = tamper ? new Uint8Array(32).fill(0xde) : blake3(pubBytes);
-  return {
+  const proof: ZkProof = {
     framework:     "mock",
     program_id:    "bca-green-mark-2021-v1-mock",
     proof_bytes:   b64Encode(hash),
     public_values: btoa(json),
   };
-}
-
-function makeRecord(seq: number, att?: GreenMarkAttestation, tamper = false): AuditRecord {
-  return {
-    sequence:        seq,
-    timestamp_ms:    1_778_000_000_000 + seq * 1000,
-    record_hash_hex: "a".repeat(64),
-    ...(att ? { zk_proof: makeProof(att, tamper) } : {}),
-  };
+  return { sequence: seq, timestamp_ms: 1_778_000_000_000 + seq * 1000, record_hash_hex: "a".repeat(64), zk_proof: proof };
 }
 
 function makeEnv(
   ptrBody: { run_id: string; last_seq: number } | null,
   auditObjects: Record<string, AuditRecord>,
+  useLegacyPtr = false,
 ): Env {
   return {
     CLARUS_DEV_PUBLIC_RAW: {
       get: vi.fn(async (key: string) => {
-        if (key.startsWith("zkp-latest/") && ptrBody) {
+        const ptrKey = useLegacyPtr ? "zkp-latest/" : "compliance-latest/";
+        if (key.startsWith(ptrKey) && ptrBody) {
           return { text: async () => JSON.stringify(ptrBody) };
         }
         return null;
@@ -73,20 +79,21 @@ function req(site: string) {
   return new Request(`https://clarus.edgesentry.io/api/verify?site=${encodeURIComponent(site)}`);
 }
 
-// ── Tests ─────────────────────────────────────────────────────────────────────
+// ── Tests — new format (top-level attestation) ────────────────────────────────
 
-describe("GET /api/verify", () => {
-  it("returns valid:true for a Gold attestation with correct mock proof", async () => {
+describe("GET /api/verify — new format (top-level attestation)", () => {
+  it("returns valid:true for a Gold attestation", async () => {
     const att = makeAttestation({ cert_level: "gold", all_criteria_pass: true });
     const key = "chains/MCH-OUTLET-042/1000/00000000000000000005.json";
     const env = makeEnv({ run_id: "1000", last_seq: 5 }, { [key]: makeRecord(5, att) });
 
-    const body = await (await onRequestGet({ request: req("MCH-OUTLET-042"), env })) .json() as Record<string, unknown>;
+    const body = await (await onRequestGet({ request: req("MCH-OUTLET-042"), env })).json() as Record<string, unknown>;
 
     expect(body.valid).toBe(true);
     expect(body.cert_level).toBe("gold");
     expect(body.all_criteria_pass).toBe(true);
-    expect(body.proof_verified).toBe(true);
+    expect(body.proof_verified).toBeNull();
+    expect(body.framework).toBe("none");
     expect(body.record_hash).toBe("a".repeat(64));
     expect(body.verify_url).toContain("/api/verify?site=MCH-OUTLET-042");
   });
@@ -96,33 +103,23 @@ describe("GET /api/verify", () => {
     const key = "chains/SITE-PLAT/1000/00000000000000000000.json";
     const env = makeEnv({ run_id: "1000", last_seq: 0 }, { [key]: makeRecord(0, att) });
 
-    const body = await (await onRequestGet({ request: req("SITE-PLAT"), env })) .json() as Record<string, unknown>;
+    const body = await (await onRequestGet({ request: req("SITE-PLAT"), env })).json() as Record<string, unknown>;
     expect(body.valid).toBe(true);
     expect(body.cert_level).toBe("platinum");
   });
 
-  it("returns valid:true for a not_certified attestation (Q2 — valid proof, fails BCA)", async () => {
+  it("returns valid:true for not_certified (fails BCA, proof valid)", async () => {
     const att = makeAttestation({ cert_level: "not_certified", all_criteria_pass: false, eui_kwh_m2: 155.0 });
     const key = "chains/BLD-HIGHUSE-FAIL/1000/00000000000000000000.json";
     const env = makeEnv({ run_id: "1000", last_seq: 0 }, { [key]: makeRecord(0, att) });
 
-    const body = await (await onRequestGet({ request: req("BLD-HIGHUSE-FAIL"), env })) .json() as Record<string, unknown>;
+    const body = await (await onRequestGet({ request: req("BLD-HIGHUSE-FAIL"), env })).json() as Record<string, unknown>;
     expect(body.valid).toBe(true);
     expect(body.cert_level).toBe("not_certified");
     expect(body.all_criteria_pass).toBe(false);
   });
 
-  it("returns valid:false for a tampered proof (Q3/Q4)", async () => {
-    const att = makeAttestation({ cert_level: "gold_plus", all_criteria_pass: true });
-    const key = "chains/BLD-TAMPER-PASS/1000/00000000000000000000.json";
-    const env = makeEnv({ run_id: "1000", last_seq: 0 }, { [key]: makeRecord(0, att, true) });
-
-    const body = await (await onRequestGet({ request: req("BLD-TAMPER-PASS"), env })) .json() as Record<string, unknown>;
-    expect(body.valid).toBe(false);
-    expect(body.reason).toBe("proof_bytes_do_not_match_public_values");
-  });
-
-  it("returns 404 when no ZKP record exists", async () => {
+  it("returns 404 when no record exists", async () => {
     const env = makeEnv(null, {});
     (env.CLARUS_DEV_PUBLIC_AUDIT as any).list = vi.fn(async () => ({ objects: [] }));
 
@@ -130,7 +127,7 @@ describe("GET /api/verify", () => {
     expect(res.status).toBe(404);
     const body = await res.json() as Record<string, unknown>;
     expect(body.valid).toBe(false);
-    expect(body.reason).toBe("no_zkp_record");
+    expect(body.reason).toBe("no_record");
   });
 
   it("returns 400 when site param is missing", async () => {
@@ -139,7 +136,7 @@ describe("GET /api/verify", () => {
     expect(res.status).toBe(400);
   });
 
-  it("scans backwards to find zk_proof in earlier record", async () => {
+  it("scans backwards to find attestation in earlier record", async () => {
     const att = makeAttestation({ cert_level: "certified" });
     const env = makeEnv(
       { run_id: "1000", last_seq: 5 },
@@ -149,7 +146,7 @@ describe("GET /api/verify", () => {
       },
     );
 
-    const body = await (await onRequestGet({ request: req("SITE-A"), env })) .json() as Record<string, unknown>;
+    const body = await (await onRequestGet({ request: req("SITE-A"), env })).json() as Record<string, unknown>;
     expect(body.valid).toBe(true);
     expect(body.cert_level).toBe("certified");
   });
@@ -167,7 +164,32 @@ describe("GET /api/verify", () => {
     const key = "chains/SITE-A/1000/00000000000000000000.json";
     const env = makeEnv({ run_id: "1000", last_seq: 0 }, { [key]: { ...makeRecord(0, att), timestamp_ms: ts } });
 
-    const body = await (await onRequestGet({ request: req("SITE-A"), env })) .json() as Record<string, unknown>;
+    const body = await (await onRequestGet({ request: req("SITE-A"), env })).json() as Record<string, unknown>;
     expect(body.attested_at_ms).toBe(ts);
+  });
+});
+
+// ── Tests — legacy format (zk_proof.public_values) ────────────────────────────
+
+describe("GET /api/verify — legacy format (zk_proof)", () => {
+  it("returns valid:true for a valid mock proof", async () => {
+    const att = makeAttestation({ cert_level: "gold" });
+    const key = "chains/MCH-OUTLET-042/1000/00000000000000000005.json";
+    const env = makeEnv({ run_id: "1000", last_seq: 5 }, { [key]: makeLegacyRecord(5, att) }, true);
+
+    const body = await (await onRequestGet({ request: req("MCH-OUTLET-042"), env })).json() as Record<string, unknown>;
+    expect(body.valid).toBe(true);
+    expect(body.cert_level).toBe("gold");
+    expect(body.proof_verified).toBe(true);
+  });
+
+  it("returns valid:false for a tampered proof (Q3/Q4)", async () => {
+    const att = makeAttestation({ cert_level: "gold_plus", all_criteria_pass: true });
+    const key = "chains/BLD-TAMPER-PASS/1000/00000000000000000000.json";
+    const env = makeEnv({ run_id: "1000", last_seq: 0 }, { [key]: makeLegacyRecord(0, att, true) }, true);
+
+    const body = await (await onRequestGet({ request: req("BLD-TAMPER-PASS"), env })).json() as Record<string, unknown>;
+    expect(body.valid).toBe(false);
+    expect(body.reason).toBe("proof_bytes_do_not_match_public_values");
   });
 });

--- a/analytics/functions/api/verify.ts
+++ b/analytics/functions/api/verify.ts
@@ -1,11 +1,11 @@
 /**
  * GET /api/verify?site=<site_id>
  *
- * Layer 1 verifier — human and machine readable.
- * Returns the decoded GreenMarkAttestation with BLAKE3 proof validity.
+ * Returns the BCA Green Mark compliance attestation for a site.
+ * Reads the top-level `attestation` field written by clarus on every BCA cycle.
  *
- * Mock framework: proof_bytes = BLAKE3(public_values_bytes) — verified server-side.
- * SP1/RISC Zero:  proof_verified: null — pending ZK verifier integration.
+ * Legacy: also accepts records with `zk_proof.public_values` (old format).
+ * B2B ZKP path (SP1): tracked in edgesentry-rs#387.
  */
 
 import { blake3 } from "@noble/hashes/blake3.js";
@@ -27,7 +27,7 @@ function arrEqual(a: Uint8Array, b: Uint8Array): boolean {
   return true;
 }
 
-function verifyProof(proof: ZkProof): boolean | null {
+function verifyZkProof(proof: ZkProof): boolean | null {
   if (proof.framework === "mock") {
     try {
       const pubValBytes = b64Decode(proof.public_values);
@@ -47,27 +47,36 @@ export async function onRequestGet({ request, env }: { request: Request; env: En
 
   const record = await fetchLatestZkRecord(site, env);
   if (!record) {
-    return Response.json({ valid: false, site_id: site, reason: "no_zkp_record" }, { status: 404, headers: CORS });
+    return Response.json({ valid: false, site_id: site, reason: "no_record" }, { status: 404, headers: CORS });
   }
 
-  const proof = record.zk_proof!;
-  let att: GreenMarkAttestation;
-  try {
-    att = JSON.parse(atob(proof.public_values)) as GreenMarkAttestation;
-  } catch {
-    return Response.json({ valid: false, site_id: site, reason: "public_values_decode_failed" }, { headers: CORS });
-  }
+  // Prefer top-level attestation (new format); fall back to zk_proof.public_values (legacy)
+  let att: GreenMarkAttestation | null = null;
+  let proofVerified: boolean | null = null;
 
-  const proofValid = verifyProof(proof);
-  if (proofValid === false) {
-    return Response.json({
-      valid:       false,
-      site_id:     site,
-      reason:      "proof_bytes_do_not_match_public_values",
-      framework:   proof.framework,
-      program_id:  proof.program_id,
-      record_hash: record.record_hash_hex ?? null,
-    }, { headers: CORS });
+  if (record.attestation) {
+    att = record.attestation;
+    // No BLAKE3 check needed — integrity is guaranteed by the WORM chain + Ed25519 signature
+    proofVerified = null;
+  } else if (record.zk_proof) {
+    try {
+      att = JSON.parse(atob(record.zk_proof.public_values)) as GreenMarkAttestation;
+    } catch {
+      return Response.json({ valid: false, site_id: site, reason: "public_values_decode_failed" }, { headers: CORS });
+    }
+    proofVerified = verifyZkProof(record.zk_proof);
+    if (proofVerified === false) {
+      return Response.json({
+        valid:       false,
+        site_id:     site,
+        reason:      "proof_bytes_do_not_match_public_values",
+        framework:   record.zk_proof.framework,
+        program_id:  record.zk_proof.program_id,
+        record_hash: record.record_hash_hex ?? null,
+      }, { headers: CORS });
+    }
+  } else {
+    return Response.json({ valid: false, site_id: site, reason: "no_attestation" }, { status: 404, headers: CORS });
   }
 
   return Response.json({
@@ -78,9 +87,8 @@ export async function onRequestGet({ request, env }: { request: Request; env: En
     cop_pass:          att.cop_pass,
     lpd_pass:          att.lpd_pass,
     eui_kwh_m2:        att.eui_kwh_m2,
-    framework:         proof.framework,
-    program_id:        proof.program_id,
-    proof_verified:    proofValid, // null = SP1/RISC Zero, not yet verifiable server-side
+    framework:         record.zk_proof?.framework ?? "none",
+    proof_verified:    proofVerified,
     attested_at_ms:    record.timestamp_ms,
     record_hash:       record.record_hash_hex ?? null,
     verify_url:        `${new URL(request.url).origin}/api/verify?site=${encodeURIComponent(site)}`,

--- a/edge/.gitignore
+++ b/edge/.gitignore
@@ -6,3 +6,4 @@ config.env
 /tmp/
 .wrangler/
 chains/
+.env

--- a/edge/src/main.rs
+++ b/edge/src/main.rs
@@ -25,8 +25,7 @@ use config::Config;
 use edgesentry_audit::{generate_keypair, inspect_key, sign_record, AuditRecord};
 use edgesentry_evaluate::{evaluate, EvidenceQuality, RiskEvent};
 use edgesentry_profile::load_profile;
-use edgesentry_zkp::ZkProgram;
-use zkp::{GreenMarkInputs, GreenMarkProgram, OtIntegrityProgram, ot_sim_inputs};
+use zkp::{GreenMarkAttestation, GreenMarkInputs, OtIntegrityProgram, evaluate_green_mark, ot_sim_inputs};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -74,12 +73,9 @@ async fn main() -> Result<()> {
     };
     info!(public_key = %keypair.public_key_hex, site = %config.site_id, "Identity ready");
 
-    // ── ZKP prover (profile-specific) ─────────────────────────────────────
-    let zkp_prover: Option<Box<dyn ZkProgram>> =
-        if config.profile.contains("bca-greenmark") || config.profile.contains("bca_greenmark") {
-            info!("ZKP prover: BCA Green Mark 2021 (mock — SP1 ELF pending)");
-            Some(Box::new(GreenMarkProgram))
-        } else if config.profile.contains("ot-cyber") || config.profile.contains("ot_cyber") || config.profile.contains("cybersecurity") {
+    // OT cybersecurity ZKP prover (BCA uses direct attestation, not ZKP)
+    let ot_zkp_prover: Option<Box<dyn edgesentry_zkp::ZkProgram>> =
+        if config.profile.contains("ot-cyber") || config.profile.contains("ot_cyber") || config.profile.contains("cybersecurity") {
             info!("ZKP prover: OT Integrity — IACS UR E26/E27 (mock — SP1 ELF pending)");
             Some(Box::new(OtIntegrityProgram))
         } else {
@@ -135,59 +131,62 @@ async fn main() -> Result<()> {
             prev_hash = record_hash;
             db::insert_audit_record(&conn, &record, event)?;
 
-            // Generate ZKP proof when a profile-specific prover is active.
-            // Private inputs are built from the current frame's sensor values;
-            // only the public attestation is committed to the WORM envelope.
-            let zk_proof = zkp_prover.as_ref().and_then(|prover| {
-                let raw_inputs: Option<Vec<u8>> = match scenario {
-                    sim::Scenario::BcaGreenMark => {
-                        let sv = frames
-                            .iter()
-                            .flat_map(|f| f.entities.iter())
-                            .find_map(|e| e.sensor_values.as_ref())
-                            .cloned()
-                            .unwrap_or_default();
-                        let inputs = GreenMarkInputs {
-                            site_id: config.site_id.clone(),
-                            eui_kwh_m2: *sv.get("eui_kwh_m2").unwrap_or(&0.0) as f32,
-                            chiller_cop: *sv.get("chiller_cop").unwrap_or(&0.0) as f32,
-                            lpd_w_m2: *sv.get("lpd_w_m2").unwrap_or(&0.0) as f32,
-                            period_start_ms: now_ms.saturating_sub(config.cycle_interval_secs * 1_000),
-                            period_end_ms: now_ms,
-                        };
-                        serde_json::to_vec(&inputs).ok()
-                    }
-                    sim::Scenario::OtCybersecurity => {
-                        let inputs = ot_sim_inputs(&config.site_id, cycle, now_ms);
-                        serde_json::to_vec(&inputs).ok()
-                    }
-                    _ => None,
+            // BCA Green Mark: compute attestation directly from sensor values.
+            // The compliance result is stored as a top-level field in the envelope —
+            // no ZKP layer required for BCA certification (see docs/regulatory/sg-bca/).
+            let bca_attestation: Option<GreenMarkAttestation> =
+                if scenario == sim::Scenario::BcaGreenMark {
+                    let sv = frames
+                        .iter()
+                        .flat_map(|f| f.entities.iter())
+                        .find_map(|e| e.sensor_values.as_ref())
+                        .cloned()
+                        .unwrap_or_default();
+                    let inputs = GreenMarkInputs {
+                        site_id: config.site_id.clone(),
+                        eui_kwh_m2: *sv.get("eui_kwh_m2").unwrap_or(&0.0) as f32,
+                        chiller_cop: *sv.get("chiller_cop").unwrap_or(&0.0) as f32,
+                        lpd_w_m2: *sv.get("lpd_w_m2").unwrap_or(&0.0) as f32,
+                        period_start_ms: now_ms.saturating_sub(config.cycle_interval_secs * 1_000),
+                        period_end_ms: now_ms,
+                    };
+                    Some(evaluate_green_mark(&inputs))
+                } else {
+                    None
                 };
 
-                raw_inputs.and_then(|b| match prover.prove(&b) {
-                    Ok(proof)  => Some(proof),
-                    Err(e)     => { warn!("ZKP prove failed: {e}"); None }
-                })
+            // OT cybersecurity ZKP proof (separate from BCA attestation path)
+            let ot_zk_proof = ot_zkp_prover.as_ref().and_then(|prover| {
+                if scenario == sim::Scenario::OtCybersecurity {
+                    let inputs = ot_sim_inputs(&config.site_id, cycle, now_ms);
+                    serde_json::to_vec(&inputs).ok().and_then(|b| match prover.prove(&b) {
+                        Ok(proof) => Some(proof),
+                        Err(e)    => { warn!("ZKP prove failed: {e}"); None }
+                    })
+                } else {
+                    None
+                }
             });
 
-            let envelope = build_audit_envelope(&record, record_hash, event, zk_proof.as_ref());
+            let envelope = build_audit_envelope(
+                &record, record_hash, event,
+                bca_attestation.as_ref(),
+                ot_zk_proof.as_ref(),
+            );
             let worm_key = format!("chains/{}/{run_id}/{:020}.json", config.site_id, sequence);
             match storage.put_audit(&worm_key, serde_json::to_vec(&envelope)?.into()).await {
                 Ok(()) => {
-                    // Update the zkp-latest pointer whenever a ZKP proof is attached,
-                    // so documaris can discover the newest attested record via a single
-                    // strongly-consistent GET without waiting for R2 list consistency.
-                    if zk_proof.is_some() {
+                    // Write compliance-latest pointer on every BCA cycle so documaris
+                    // can discover the newest record without waiting for R2 list consistency.
+                    if bca_attestation.is_some() {
                         let pointer = serde_json::json!({
                             "run_id": run_id.to_string(),
                             "last_seq": sequence,
                             "site_id": config.site_id,
                         });
-                        // Write pointer to raw bucket (not audit) — pointers are
-                        // mutable navigation hints, not WORM evidence records.
-                        let ptr_key = format!("zkp-latest/{}.json", config.site_id);
+                        let ptr_key = format!("compliance-latest/{}.json", config.site_id);
                         if let Err(e) = storage.put_raw(&ptr_key, serde_json::to_vec(&pointer)?.into()).await {
-                            warn!("zkp-latest pointer update failed: {e}");
+                            warn!("compliance-latest pointer update failed: {e}");
                         }
                     }
                 }
@@ -303,13 +302,16 @@ fn now_millis() -> u64 {
 /// Pre-computes hex fields so browsers can verify the hash chain with a
 /// simple string comparison — no postcard or BLAKE3 needed in the browser.
 ///
-/// When `zk_proof` is present the envelope includes `zk_proof` so that
-/// documaris can verify the attestation without accessing raw sensor data.
+/// `attestation` is the BCA Green Mark compliance result stored at the
+/// top level — readable without any ZKP knowledge.
+///
+/// `ot_zk_proof` is the optional OT cybersecurity ZKP proof (separate path).
 fn build_audit_envelope(
     record: &AuditRecord,
     record_hash: [u8; 32],
     event: &RiskEvent,
-    zk_proof: Option<&edgesentry_zkp::ZkProof>,
+    attestation: Option<&GreenMarkAttestation>,
+    ot_zk_proof: Option<&edgesentry_zkp::ZkProof>,
 ) -> serde_json::Value {
     let mut envelope = serde_json::json!({
         "device_id":             record.device_id,
@@ -327,11 +329,15 @@ fn build_audit_envelope(
         "entity_ids":            event.entity_ids,
     });
 
-    if let Some(proof) = zk_proof {
+    if let Some(att) = attestation {
+        envelope["attestation"] = serde_json::to_value(att).unwrap_or(serde_json::Value::Null);
+    }
+
+    if let Some(proof) = ot_zk_proof {
         envelope["zk_proof"] = serde_json::json!({
-            "framework":    proof.framework,
-            "program_id":   proof.program_id,
-            "proof_bytes":  proof.proof_bytes,
+            "framework":     proof.framework,
+            "program_id":    proof.program_id,
+            "proof_bytes":   proof.proof_bytes,
             "public_values": proof.public_values,
         });
     }
@@ -376,7 +382,7 @@ mod tests {
     fn envelope_has_all_required_hex_fields() {
         let (record, hash) = make_record(0, AuditRecord::zero_hash());
         let event = make_event();
-        let env = build_audit_envelope(&record, hash, &event, None);
+        let env = build_audit_envelope(&record, hash, &event, None, None);
 
         for field in ["record_hash_hex", "prev_record_hash_hex", "payload_hash_hex", "signature_hex"] {
             let val = env[field].as_str().expect(field);
@@ -400,9 +406,9 @@ mod tests {
         let (r1, h1) = make_record(1, h0);
         let (r2, _)  = make_record(2, h1);
 
-        let e0 = build_audit_envelope(&r0, h0, &event, None);
-        let e1 = build_audit_envelope(&r1, h1, &event, None);
-        let e2 = build_audit_envelope(&r2, [0u8; 32], &event, None);
+        let e0 = build_audit_envelope(&r0, h0, &event, None, None);
+        let e1 = build_audit_envelope(&r1, h1, &event, None, None);
+        let e2 = build_audit_envelope(&r2, [0u8; 32], &event, None, None);
 
         // genesis: prev_record_hash of record 0 is all zeros
         assert_eq!(e0["prev_record_hash_hex"].as_str().unwrap(), "0".repeat(64));
@@ -422,7 +428,7 @@ mod tests {
     fn envelope_event_fields_match_risk_event() {
         let (record, hash) = make_record(42, AuditRecord::zero_hash());
         let event = make_event();
-        let env = build_audit_envelope(&record, hash, &event, None);
+        let env = build_audit_envelope(&record, hash, &event, None, None);
 
         assert_eq!(env["rule_id"].as_str().unwrap(), "RESTRICTED_ZONE_APPROACH");
         assert_eq!(env["sequence"].as_u64().unwrap(), 42);

--- a/edge/src/zkp/green_mark.rs
+++ b/edge/src/zkp/green_mark.rs
@@ -132,10 +132,13 @@ pub fn evaluate(inputs: &GreenMarkInputs) -> GreenMarkAttestation {
 /// 2. Compile `guest/green_mark.rs` with `cargo prove build`
 /// 3. Replace `ZkFramework::Mock` with `ZkFramework::Sp1`
 /// 4. Replace the mock proof bytes with the real SP1 prover call
+// Retained for the SP1 upgrade path (edgesentry-rs#387); not used in the BCA default path.
+#[allow(dead_code)]
 pub struct GreenMarkProgram;
 
 /// Stable identifier for the BCA Green Mark 2021 guest program.
 /// Will be replaced by the SP1 vkey hash once the ELF is compiled.
+#[allow(dead_code)]
 pub const PROGRAM_ID: &str = "bca-green-mark-2021-v1-mock";
 
 impl ZkProgram for GreenMarkProgram {

--- a/edge/src/zkp/mod.rs
+++ b/edge/src/zkp/mod.rs
@@ -2,6 +2,4 @@ pub mod green_mark;
 pub mod ot_integrity;
 
 pub use green_mark::{GreenMarkAttestation, GreenMarkInputs, evaluate as evaluate_green_mark};
-#[allow(unused_imports)]
-pub use green_mark::GreenMarkProgram; // retained for tests and future SP1 integration
 pub use ot_integrity::{OtIntegrityProgram, sim_inputs as ot_sim_inputs};

--- a/edge/src/zkp/mod.rs
+++ b/edge/src/zkp/mod.rs
@@ -1,5 +1,7 @@
 pub mod green_mark;
 pub mod ot_integrity;
 
-pub use green_mark::{GreenMarkProgram, GreenMarkInputs};
+pub use green_mark::{GreenMarkAttestation, GreenMarkInputs, evaluate as evaluate_green_mark};
+#[allow(unused_imports)]
+pub use green_mark::GreenMarkProgram; // retained for tests and future SP1 integration
 pub use ot_integrity::{OtIntegrityProgram, sim_inputs as ot_sim_inputs};


### PR DESCRIPTION
Closes #124

## What changed

### clarus/edge
- `build_audit_envelope()` now writes a top-level `attestation` field (plain JSON — no base64) populated directly from `GreenMarkAttestation`
- `zk_proof` is removed from the BCA default path; retained only for the OT cybersecurity scenario
- `compliance-latest/{site}.json` pointer written every BCA cycle (was gated on `zk_proof` being present)

### clarus/analytics
- `_zk-types.ts`: `AuditRecord` gains `attestation?: GreenMarkAttestation` field
- `_zk-fetch.ts`: reads `compliance-latest/` first, falls back to `zkp-latest/` for existing R2 records
- `verify.ts`: reads `record.attestation` directly; falls back to `zk_proof.public_values` for legacy records; BLAKE3 check retained only on the legacy path

## Why
BCA Green Mark certification does not require ZKP. Compliance results (cert_level, EUI, COP, LPD) were buried inside `zk_proof.public_values` (base64-encoded JSON-in-JSON), making them unreadable without ZKP knowledge. Moving them to a top-level field aligns the data model with what BCA actually needs. See `docs/regulatory/sg-bca/sg-bca-greenmark.md`.

## Test plan

- [x] 41 Rust unit tests pass (`cargo test`)
- [x] 57 TS tests pass (`npm test`) — new-format and legacy-format suites
- [x] Edge daemon runs with `site=MCH-OUTLET-042`; `compliance-latest/MCH-OUTLET-042.json` written to R2
- [x] Audit record in R2 has top-level `attestation` field (plain JSON) with `zk_proof: null` — verified via curl
- [ ] After merge+deploy: `curl /api/verify?site=MCH-OUTLET-042` returns `valid:true`, `framework: "none"`, `proof_verified: null`
- [ ] After merge+deploy: tampered records (BLD-TAMPER-PASS) still return `valid:false` via legacy path

## Follow-up
documaris#67 — update `attestation.ts` to read `record.attestation` and remove ZKP UI elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)