### PR TITLE
ci: cross-compile clarus-edge for aarch64 + RPi5 deploy scripts

### DIFF
--- a/.github/workflows/build-edge-aarch64.yml
+++ b/.github/workflows/build-edge-aarch64.yml
@@ -1,0 +1,83 @@
+name: Build edge (aarch64)
+
+on:
+  push:
+    tags: ["v*"]
+    paths:
+      - "edge/**"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: build-edge-aarch64-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Cross-compile clarus-edge → aarch64-unknown-linux-gnu
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout clarus
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          path: clarus
+
+      - name: Checkout edgesentry-rs
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          repository: edgesentry/edgesentry-rs
+          path: edgesentry-rs
+
+      - name: Install Rust stable
+        run: |
+          rustup update stable
+          rustup target add aarch64-unknown-linux-gnu
+
+      - name: Install Zig
+        uses: goto-bus-stop/setup-zig@v2
+        with:
+          version: 0.14.0
+
+      - name: Install cargo-zigbuild
+        run: cargo install cargo-zigbuild --locked
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            clarus/edge/target
+          key: aarch64-cargo-${{ hashFiles('clarus/edge/Cargo.lock') }}
+          restore-keys: aarch64-cargo-
+
+      - name: Build clarus-edge (aarch64)
+        working-directory: clarus/edge
+        run: |
+          cargo zigbuild \
+            --target aarch64-unknown-linux-gnu.2.31 \
+            --release \
+            --bin clarus-edge
+
+      - name: Rename binary
+        run: |
+          cp clarus/edge/target/aarch64-unknown-linux-gnu/release/clarus-edge \
+             clarus-edge-aarch64-linux
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: clarus-edge-aarch64-linux
+          fail_on_unmatched_files: true
+
+      - name: Upload as workflow artifact (non-tag builds)
+        uses: actions/upload-artifact@v4
+        if: "!startsWith(github.ref, 'refs/tags/')"
+        with:
+          name: clarus-edge-aarch64-linux
+          path: clarus-edge-aarch64-linux
+          retention-days: 7

--- a/.github/workflows/build-edge-aarch64.yml
+++ b/.github/workflows/build-edge-aarch64.yml
@@ -1,6 +1,9 @@
 name: Build edge (aarch64)
 
 on:
+  pull_request:
+    paths:
+      - "edge/**"
   push:
     tags: ["v*"]
     paths:
@@ -74,9 +77,9 @@ jobs:
           files: clarus-edge-aarch64-linux
           fail_on_unmatched_files: true
 
-      - name: Upload as workflow artifact (non-tag builds)
+      - name: Upload as workflow artifact (main push only)
         uses: actions/upload-artifact@v4
-        if: "!startsWith(github.ref, 'refs/tags/')"
+        if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/')
         with:
           name: clarus-edge-aarch64-linux
           path: clarus-edge-aarch64-linux

--- a/edge/deploy/README.md
+++ b/edge/deploy/README.md
@@ -1,0 +1,50 @@
+# RPi5 deployment
+
+## First-time setup
+
+```bash
+# 1. Copy systemd service
+sudo cp clarus-edge.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable clarus-edge
+
+# 2. Download and install the latest binary
+chmod +x update.sh
+./update.sh
+
+# 3. Copy and edit config
+cp ../config.env.example ../config.env
+# edit config.env — set R2 credentials, profile, site ID
+
+# 4. Start
+sudo systemctl start clarus-edge
+sudo systemctl status clarus-edge
+```
+
+## Updating to a new release
+
+```bash
+cd ~/clarus/edge/deploy
+./update.sh
+```
+
+The script downloads the latest `clarus-edge-aarch64-linux` binary from GitHub Releases,
+installs it to `/usr/local/bin/clarus-edge`, and restarts the systemd service.
+
+## Logs
+
+```bash
+journalctl -u clarus-edge -f
+```
+
+## How builds work
+
+Every push to `main` that touches `edge/` (or any new version tag) triggers
+`.github/workflows/build-edge-aarch64.yml`:
+
+1. Checks out both `clarus` and `edgesentry-rs`
+2. Cross-compiles with `cargo-zigbuild` (aarch64-unknown-linux-gnu, glibc 2.31+)
+3. On a version tag: uploads binary to the GitHub Release
+4. On non-tag pushes: uploads as a workflow artifact (7-day retention)
+
+No Docker required. No SSH inbound to RPi5 required.

--- a/edge/deploy/README.md
+++ b/edge/deploy/README.md
@@ -4,9 +4,9 @@
 
 ```bash
 # 1. Copy systemd service
-sudo cp clarus-edge.service /etc/systemd/system/
+sudo cp clarus-edge@.service /etc/systemd/system/
 sudo systemctl daemon-reload
-sudo systemctl enable clarus-edge
+sudo systemctl enable clarus-edge@$(whoami)
 
 # 2. Download and install the latest binary
 chmod +x update.sh
@@ -17,8 +17,8 @@ cp ../config.env.example ../config.env
 # edit config.env — set R2 credentials, profile, site ID
 
 # 4. Start
-sudo systemctl start clarus-edge
-sudo systemctl status clarus-edge
+sudo systemctl start clarus-edge@$(whoami)
+sudo systemctl status clarus-edge@$(whoami)
 ```
 
 ## Updating to a new release
@@ -34,7 +34,7 @@ installs it to `/usr/local/bin/clarus-edge`, and restarts the systemd service.
 ## Logs
 
 ```bash
-journalctl -u clarus-edge -f
+journalctl -u clarus-edge@$(whoami) -f
 ```
 
 ## How builds work

--- a/edge/deploy/clarus-edge.service
+++ b/edge/deploy/clarus-edge.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=EdgeSentry clarus-edge daemon
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=yohei
+WorkingDirectory=/home/yohei/clarus/edge
+EnvironmentFile=/home/yohei/clarus/edge/config.env
+ExecStart=/usr/local/bin/clarus-edge
+Restart=on-failure
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/edge/deploy/clarus-edge@.service
+++ b/edge/deploy/clarus-edge@.service
@@ -5,9 +5,9 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-User=yohei
-WorkingDirectory=/home/yohei/clarus/edge
-EnvironmentFile=/home/yohei/clarus/edge/config.env
+User=%i
+WorkingDirectory=%h/clarus/edge
+EnvironmentFile=%h/clarus/edge/config.env
 ExecStart=/usr/local/bin/clarus-edge
 Restart=on-failure
 RestartSec=10

--- a/edge/deploy/update.sh
+++ b/edge/deploy/update.sh
@@ -51,11 +51,13 @@ sudo mv "${INSTALL_PATH}.tmp" "$INSTALL_PATH"
 
 echo "[update.sh] Installed to $INSTALL_PATH"
 
-if systemctl is-active --quiet clarus-edge 2>/dev/null; then
-  echo "[update.sh] Restarting clarus-edge service..."
-  sudo systemctl restart clarus-edge
+SERVICE="clarus-edge@$(whoami)"
+
+if systemctl is-active --quiet "$SERVICE" 2>/dev/null; then
+  echo "[update.sh] Restarting $SERVICE..."
+  sudo systemctl restart "$SERVICE"
   echo "[update.sh] Done. Status:"
-  systemctl status clarus-edge --no-pager --lines=5
+  systemctl status "$SERVICE" --no-pager --lines=5
 else
-  echo "[update.sh] Service not running. Start with: sudo systemctl start clarus-edge"
+  echo "[update.sh] Service not running. Start with: sudo systemctl start $SERVICE"
 fi

--- a/edge/deploy/update.sh
+++ b/edge/deploy/update.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Pull latest clarus-edge binary from GitHub Releases and restart the service.
+#
+# Usage:
+#   ./update.sh            # install latest release
+#   ./update.sh --dry-run  # show what would be downloaded, no changes
+#
+# Run once to set up:
+#   sudo cp clarus-edge.service /etc/systemd/system/
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable clarus-edge
+#   ./update.sh            # first install
+#   sudo systemctl start clarus-edge
+
+set -euo pipefail
+
+REPO="edgesentry/clarus"
+ASSET="clarus-edge-aarch64-linux"
+INSTALL_PATH="/usr/local/bin/clarus-edge"
+DRY_RUN=false
+
+for arg in "$@"; do
+  [[ "$arg" == "--dry-run" ]] && DRY_RUN=true
+done
+
+echo "[update.sh] Fetching latest release info from $REPO..."
+RELEASE_JSON=$(curl -sf "https://api.github.com/repos/$REPO/releases/latest")
+
+TAG=$(echo "$RELEASE_JSON" | jq -r '.tag_name')
+DOWNLOAD_URL=$(echo "$RELEASE_JSON" | jq -r ".assets[] | select(.name == \"$ASSET\") | .browser_download_url")
+
+if [[ -z "$DOWNLOAD_URL" || "$DOWNLOAD_URL" == "null" ]]; then
+  echo "[update.sh] ERROR: asset '$ASSET' not found in release $TAG"
+  echo "[update.sh] Available assets:"
+  echo "$RELEASE_JSON" | jq -r '.assets[].name'
+  exit 1
+fi
+
+echo "[update.sh] Latest release: $TAG"
+echo "[update.sh] Download URL:   $DOWNLOAD_URL"
+
+if $DRY_RUN; then
+  echo "[update.sh] Dry-run — no changes made."
+  exit 0
+fi
+
+echo "[update.sh] Downloading..."
+curl -fL "$DOWNLOAD_URL" -o "${INSTALL_PATH}.tmp"
+chmod +x "${INSTALL_PATH}.tmp"
+sudo mv "${INSTALL_PATH}.tmp" "$INSTALL_PATH"
+
+echo "[update.sh] Installed to $INSTALL_PATH"
+
+if systemctl is-active --quiet clarus-edge 2>/dev/null; then
+  echo "[update.sh] Restarting clarus-edge service..."
+  sudo systemctl restart clarus-edge
+  echo "[update.sh] Done. Status:"
+  systemctl status clarus-edge --no-pager --lines=5
+else
+  echo "[update.sh] Service not running. Start with: sudo systemctl start clarus-edge"
+fi


### PR DESCRIPTION
## Summary

- **GitHub Actions workflow** (`build-edge-aarch64.yml`): cross-compiles `clarus-edge` for `aarch64-unknown-linux-gnu` using `cargo-zigbuild` (no Docker, no GCC 14 segfault)
- **systemd service** (`edge/deploy/clarus-edge.service`): manages clarus-edge on RPi5
- **Update script** (`edge/deploy/update.sh`): pull-model deploy — RPi5 fetches latest binary from GitHub Releases and restarts the service. No inbound SSH required.

## How it works

```
git push (tag or edge/** change)
  → GitHub Actions: cargo-zigbuild aarch64-unknown-linux-gnu.2.31
  → on tag: binary attached to GitHub Release
  → on non-tag: binary uploaded as workflow artifact (7 days)

RPi5:
  ./deploy/update.sh
  → curl GitHub Releases API → download clarus-edge-aarch64-linux
  → install to /usr/local/bin/clarus-edge
  → systemctl restart clarus-edge
```

## Notes

- `cargo-zigbuild` handles `duckdb = { features = ["bundled"] }` C++ cross-compilation cleanly — the `CC=clang` workaround (GCC 14 aarch64 segfault) is not needed
- Both `clarus` and `edgesentry-rs` are checked out at the same level to preserve `../../edgesentry-rs` path deps in `edge/Cargo.toml`
- glibc 2.31 target is compatible with RPi OS Bookworm (glibc 2.36)

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)