### PR TITLE
fix(ci): replace non-allowed actions with inline scripts and pinned SHAs

### DIFF
--- a/.github/workflows/build-edge-aarch64.yml
+++ b/.github/workflows/build-edge-aarch64.yml
@@ -40,15 +40,19 @@ jobs:
           rustup target add aarch64-unknown-linux-gnu
 
       - name: Install Zig
-        uses: goto-bus-stop/setup-zig@v2
-        with:
-          version: 0.14.0
+        run: |
+          ZIG_VERSION="0.14.0"
+          ZIG_TAR="zig-linux-x86_64-${ZIG_VERSION}.tar.xz"
+          curl -fL "https://ziglang.org/download/${ZIG_VERSION}/${ZIG_TAR}" -o /tmp/zig.tar.xz
+          tar -xf /tmp/zig.tar.xz -C /tmp
+          sudo mv "/tmp/zig-linux-x86_64-${ZIG_VERSION}" /usr/local/zig
+          echo "/usr/local/zig" >> "$GITHUB_PATH"
 
       - name: Install cargo-zigbuild
         run: cargo install cargo-zigbuild --locked
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: |
             ~/.cargo/registry
@@ -71,14 +75,18 @@ jobs:
              clarus-edge-aarch64-linux
 
       - name: Upload to GitHub Release
-        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
-        with:
-          files: clarus-edge-aarch64-linux
-          fail_on_unmatched_files: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ github.ref_name }}"
+          gh release create "$TAG" --repo "$GITHUB_REPOSITORY" \
+            --title "$TAG" --generate-notes 2>/dev/null || true
+          gh release upload "$TAG" clarus-edge-aarch64-linux \
+            --repo "$GITHUB_REPOSITORY" --clobber
 
       - name: Upload as workflow artifact (main push only)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/')
         with:
           name: clarus-edge-aarch64-linux


### PR DESCRIPTION
Fixes action policy errors — replaces third-party actions with inline scripts and pins GitHub-owned actions to full SHAs.

## Changes

| Before | After |
|---|---|
| `goto-bus-stop/setup-zig@v2` | inline `curl` install of Zig 0.14.0 |
| `softprops/action-gh-release@v2` | `gh release create` + `gh release upload` |
| `actions/cache@v4` | pinned to `0057852` |
| `actions/upload-artifact@v4` | pinned to `ea165f8` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)