### PR TITLE
fix(ci): upload artifact on workflow_dispatch too

### DIFF
--- a/.github/workflows/build-edge-aarch64.yml
+++ b/.github/workflows/build-edge-aarch64.yml
@@ -85,9 +85,9 @@ jobs:
           gh release upload "$TAG" clarus-edge-aarch64-linux \
             --repo "$GITHUB_REPOSITORY" --clobber
 
-      - name: Upload as workflow artifact (main push only)
+      - name: Upload as workflow artifact (non-tag builds)
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
-        if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/')
+        if: "!startsWith(github.ref, 'refs/tags/')"
         with:
           name: clarus-edge-aarch64-linux
           path: clarus-edge-aarch64-linux


### PR DESCRIPTION
The artifact upload condition was `github.event_name == 'push'` which excluded `workflow_dispatch`. Changed to `!startsWith(github.ref, 'refs/tags/')` so any non-tag build (push, PR, manual) uploads the artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)