### PR TITLE
feat(edge): AIS UDP ingest for RPi5 SWaP benchmark (closes #138)

### DIFF
--- a/edge/Cargo.lock
+++ b/edge/Cargo.lock
@@ -528,6 +528,7 @@ dependencies = [
  "duckdb",
  "edgesentry-audit",
  "edgesentry-evaluate",
+ "edgesentry-ingest",
  "edgesentry-profile",
  "edgesentry-types",
  "edgesentry-zkp",

--- a/edge/Cargo.toml
+++ b/edge/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 [dependencies]
 # EdgeSentry library crates
 edgesentry-types    = { path = "../../edgesentry-rs/crates/edgesentry-types" }
+edgesentry-ingest   = { path = "../../edgesentry-rs/crates/edgesentry-ingest" }
 edgesentry-evaluate = { path = "../../edgesentry-rs/crates/edgesentry-evaluate" }
 edgesentry-profile  = { path = "../../edgesentry-rs/crates/edgesentry-profile" }
 edgesentry-audit    = { path = "../../edgesentry-rs/crates/edgesentry-audit" }

--- a/edge/config.env.example
+++ b/edge/config.env.example
@@ -37,6 +37,11 @@ AUDIT_BUCKET=clarus-dev-public-audit
 EDS_BIN=../../edgesentry-rs/target/debug/eds
 PROFILES_DIR=../profiles
 
+# ── Entity source (clarus#138) ────────────────────────────────────────────────
+# SOURCE=sim                         # synthetic CV stream (default)
+# SOURCE=ais://0.0.0.0:9100          # NMEA UDP — pair with edgesentry-rs nmea_udp_replay.py
+# AIS_UDP_ADDR=127.0.0.1:9100        # shorthand (overrides ais:// host in SOURCE)
+
 # ── Timing ────────────────────────────────────────────────────────────────────
 CYCLE_INTERVAL=2          # seconds between sim cycles
 HEARTBEAT_INTERVAL=30     # seconds between heartbeat uploads

--- a/edge/demo/rpi5_swap_benchmark.sh
+++ b/edge/demo/rpi5_swap_benchmark.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# rpi5_swap_benchmark.sh — clarus-edge SWaP sample with AIS UDP (clarus#138)
+#
+# Runs clarus-edge in AIS mode with NMEA replay (same fixture as edgesentry-rs #404).
+# Measures CPU% / RSS of the clarus-edge process. For authoritative C2 annex numbers,
+# run on physical RPi5 (aarch64) and paste results into c2-annex-a.md.
+#
+# Usage:
+#   ./demo/rpi5_swap_benchmark.sh
+#   ./demo/rpi5_swap_benchmark.sh --duration 30 --speed 30
+#
+# Live stream (dev laptop → RPi5):
+#   USE_LIVE=1 AISSTREAM_API_KEY=... ./demo/rpi5_swap_benchmark.sh --host <pi-ip>
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(cd "$ROOT/../.." && pwd)"
+BIN="${CLARUS_BIN:-$ROOT/target/debug/clarus-edge}"
+NMEA="${NMEA_FILE:-$REPO_ROOT/edgesentry-rs/demo/sg-strait-15min.nmea}"
+REPLAY="$REPO_ROOT/edgesentry-rs/tools/nmea_udp_replay.py"
+UDP_HOST="127.0.0.1"
+UDP_PORT=9100
+DURATION=60
+SPEED=15
+SKIP_BUILD=0
+USE_LIVE="${USE_LIVE:-0}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --duration) DURATION="$2"; shift 2 ;;
+    --speed) SPEED="$2"; shift 2 ;;
+    --host) UDP_HOST="$2"; shift 2 ;;
+    --port) UDP_PORT="$2"; shift 2 ;;
+    --skip-build) SKIP_BUILD=1; shift ;;
+    -h|--help)
+      sed -n '2,14p' "$0"
+      exit 0
+      ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ "$SKIP_BUILD" -eq 0 ]]; then
+  echo "==> cargo build -p clarus-edge (edge/)"
+  (cd "$ROOT" && cargo build)
+fi
+
+if [[ ! -x "$BIN" ]]; then
+  echo "error: clarus-edge not found — run: (cd edge && cargo build)" >&2
+  exit 1
+fi
+
+if [[ ! -f "$NMEA" ]] && [[ "$USE_LIVE" != "1" ]]; then
+  echo "error: NMEA fixture missing: $NMEA" >&2
+  exit 1
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"; kill $(jobs -p) 2>/dev/null || true' EXIT
+
+DB_PATH="$TMP/clarus_bench.db"
+export SITE_ID="${SITE_ID:-bench-ais-001}"
+export PROFILE="${PROFILE:-sg-maritime-security}"
+export PROFILES_DIR="${PROFILES_DIR:-$ROOT/../profiles}"
+export SOURCE="ais://${UDP_HOST}:${UDP_PORT}"
+export STORAGE_BACKEND="${STORAGE_BACKEND:-minio}"
+export DB_PATH
+export CYCLE_INTERVAL="${CYCLE_INTERVAL:-1}"
+export HEARTBEAT_INTERVAL="${HEARTBEAT_INTERVAL:-3600}"
+
+echo "==> Starting clarus-edge (AIS UDP ${UDP_HOST}:${UDP_PORT})"
+"$BIN" >"$TMP/clarus.log" 2>&1 &
+EDGE_PID=$!
+sleep 2
+
+if ! kill -0 "$EDGE_PID" 2>/dev/null; then
+  echo "error: clarus-edge failed to start" >&2
+  cat "$TMP/clarus.log" >&2
+  exit 1
+fi
+
+feed() {
+  if [[ "$USE_LIVE" == "1" ]]; then
+    python3 "$REPO_ROOT/edgesentry-rs/tools/aisstream_udp_bridge.py" \
+      --host "$UDP_HOST" --port "$UDP_PORT" --duration "$DURATION"
+  else
+    python3 "$REPLAY" "$NMEA" --host "$UDP_HOST" --port "$UDP_PORT" \
+      --speed "$SPEED" --duration "$DURATION" --loop
+  fi
+}
+
+echo "==> Sampling clarus-edge for ${DURATION}s (pid $EDGE_PID)"
+feed &
+FEED_PID=$!
+
+CPU_MAX=0
+RSS_MAX_KB=0
+END=$((SECONDS + DURATION))
+while [[ $SECONDS -lt $END ]]; do
+  if kill -0 "$EDGE_PID" 2>/dev/null; then
+    read -r CPU RSS <<<"$(ps -p "$EDGE_PID" -o %cpu= -o rss= 2>/dev/null | tr -d ' ')" || true
+    if [[ -n "${CPU:-}" ]]; then
+      CPU_INT=$(python3 -c "import math; print(int(math.ceil(float('${CPU}' or 0))))")
+      (( CPU_INT > CPU_MAX )) && CPU_MAX=$CPU_INT
+      RSS_KB=$RSS
+      if [[ "$(uname -s)" == "Darwin" ]]; then
+        RSS_KB=$((RSS / 1024))
+      fi
+      (( RSS_KB > RSS_MAX_KB )) && RSS_MAX_KB=$RSS_KB
+    fi
+  fi
+  sleep 1
+done
+
+wait "$FEED_PID" 2>/dev/null || true
+kill "$EDGE_PID" 2>/dev/null || true
+wait "$EDGE_PID" 2>/dev/null || true
+
+EVENTS=$(python3 -c "
+import duckdb
+con = duckdb.connect('$DB_PATH', read_only=True)
+try:
+    n = con.execute('SELECT count(*) FROM audit_chain').fetchone()[0]
+except Exception:
+    n = 0
+print(n)
+" 2>/dev/null || echo 0)
+
+RULES=$(python3 -c "
+import duckdb
+con = duckdb.connect('$DB_PATH', read_only=True)
+try:
+    rows = con.execute('SELECT DISTINCT rule_id FROM audit_chain').fetchall()
+    print(', '.join(r[0] for r in rows) or '(none)')
+except Exception:
+    print('(none)')
+" 2>/dev/null || echo "(none)")
+
+RSS_MB=$(python3 -c "print(f'{$RSS_MAX_KB / 1024:.1f}')")
+
+echo ""
+echo "┌─────────────────────────────────────────────────────────────┐"
+echo "│  clarus-edge SWaP benchmark (clarus#138)                    │"
+echo "├─────────────────────────────────────────────────────────────┤"
+printf "│  Source        %-44s │\n" "$([ "$USE_LIVE" = 1 ] && echo live aisstream || echo replay)"
+printf "│  Duration      %-44s │\n" "${DURATION}s @ ${SPEED}×"
+printf "│  Audit records %-44s │\n" "$EVENTS"
+printf "│  Rules fired   %-44s │\n" "$RULES"
+printf "│  CPU (max)     %-44s │\n" "${CPU_MAX}%"
+printf "│  RSS (max)     %-44s │\n" "${RSS_MB} MB"
+echo "└─────────────────────────────────────────────────────────────┘"
+echo ""
+echo "Log: $TMP/clarus.log"
+echo "Update edgesentry-commercial c2-annex-a.md after RPi5 hardware run."
+
+if [[ "$EVENTS" -eq 0 ]]; then
+  echo "warning: no audit records — check replay / profile / log" >&2
+  exit 1
+fi
+
+echo "OK"

--- a/edge/src/config.rs
+++ b/edge/src/config.rs
@@ -15,6 +15,14 @@ pub struct Config {
     #[arg(long, env = "PROFILES_DIR", default_value = "../profiles")]
     pub profiles_dir: String,
 
+    /// Entity source: `sim` (default) or `ais` / `ais://HOST:PORT` for NMEA UDP.
+    #[arg(long, env = "SOURCE", default_value = "sim")]
+    pub source: String,
+
+    /// Shorthand bind address for AIS UDP (overrides host in `SOURCE` when set).
+    #[arg(long, env = "AIS_UDP_ADDR")]
+    pub ais_udp_addr: Option<String>,
+
     // ── Storage backend ───────────────────────────────────────────────────
 
     /// "wrangler" (default), "s3" for any S3-compatible endpoint, "minio" for local MinIO.

--- a/edge/src/ingest_ais.rs
+++ b/edge/src/ingest_ais.rs
@@ -1,0 +1,164 @@
+//! Live AIS NMEA UDP ingest for clarus-edge (clarus#138).
+//!
+//! Binds `edgesentry-ingest::AisAdapter` on a background thread and delivers
+//! entity batches to the main loop as `sim::Frame` values.
+
+use std::path::Path;
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use edgesentry_ingest::ais_nmea::{AisAdapter, load_port_ref};
+use edgesentry_types::EntityClass;
+
+use crate::config::Config;
+use crate::sim::Frame;
+
+/// Blocking receiver fed by a dedicated UDP reader thread.
+pub struct AisIngest {
+    rx: mpsc::Receiver<Vec<edgesentry_types::Entity>>,
+}
+
+impl AisIngest {
+    pub fn open(bind_addr: &str, profile_dir: &Path) -> Result<Self> {
+        let params_path = profile_dir.join("params.toml");
+        let params_str = std::fs::read_to_string(&params_path)
+            .with_context(|| format!("read {}", params_path.display()))?;
+        let port_ref = load_port_ref(&params_str)
+            .map_err(|e| anyhow::anyhow!("params.toml: {e}"))?;
+
+        let (tx, rx) = mpsc::channel();
+        let addr = bind_addr.to_string();
+
+        std::thread::Builder::new()
+            .name("ais-udp-ingest".into())
+            .spawn(move || {
+                let mut adapter = match AisAdapter::bind(&addr, port_ref) {
+                    Ok(a) => a,
+                    Err(e) => {
+                        tracing::error!(%addr, "AIS UDP bind failed: {e}");
+                        return;
+                    }
+                };
+                tracing::info!(%addr, "AIS UDP listener ready");
+                loop {
+                    match adapter.recv_entities() {
+                        Ok(entities) if !entities.is_empty() => {
+                            if tx.send(entities).is_err() {
+                                break;
+                            }
+                        }
+                        Ok(_) => {}
+                        Err(e) => tracing::warn!("AIS recv error: {e}"),
+                    }
+                }
+            })
+            .context("spawn ais-udp-ingest thread")?;
+
+        Ok(Self { rx })
+    }
+
+    /// Drain UDP batches until `deadline` (one `Frame` per recv batch).
+    pub fn collect_until(&self, deadline: Instant) -> Vec<Frame> {
+        let mut frames = Vec::new();
+        while Instant::now() < deadline {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let wait = remaining.min(Duration::from_millis(100));
+            match self.rx.recv_timeout(wait) {
+                Ok(entities) => {
+                    let timestamp_ms = entities
+                        .iter()
+                        .find(|e| e.class != EntityClass::AisGap)
+                        .map(|e| e.timestamp_ms)
+                        .unwrap_or_else(now_millis);
+                    frames.push(Frame {
+                        timestamp_ms,
+                        entities,
+                    });
+                }
+                Err(mpsc::RecvTimeoutError::Timeout) => {}
+                Err(mpsc::RecvTimeoutError::Disconnected) => break,
+            }
+        }
+        frames
+    }
+}
+
+/// Resolve AIS bind address from `SOURCE` / `AIS_UDP_ADDR`. `None` → use sim.
+pub fn ais_bind_addr(config: &Config) -> Option<String> {
+    if let Some(ref addr) = config.ais_udp_addr {
+        let addr = addr.trim();
+        if !addr.is_empty() {
+            return Some(addr.to_string());
+        }
+    }
+    let src = config.source.trim();
+    if let Some(rest) = src.strip_prefix("ais://") {
+        if !rest.is_empty() {
+            return Some(rest.to_string());
+        }
+    }
+    if src.eq_ignore_ascii_case("ais") {
+        return Some("0.0.0.0:9100".to_string());
+    }
+    None
+}
+
+fn now_millis() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+    use std::net::UdpSocket;
+    use std::path::PathBuf;
+
+    fn maritime_profile_dir() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../profiles/sg-maritime-security")
+    }
+
+    fn fixture_nmea_line() -> String {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../edgesentry-rs/demo/sg-strait-15min.nmea");
+        let content = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+        content
+            .lines()
+            .find(|l| l.trim().starts_with("!AIVDM"))
+            .map(|l| l.trim().to_string())
+            .expect("fixture must contain AIVDM sentence")
+    }
+
+    #[test]
+    fn ais_bind_addr_from_env_fields() {
+        let mut cfg = Config::parse_from(["clarus-edge"]);
+        assert!(ais_bind_addr(&cfg).is_none());
+
+        cfg.source = "ais://127.0.0.1:9101".into();
+        assert_eq!(ais_bind_addr(&cfg).as_deref(), Some("127.0.0.1:9101"));
+
+        cfg.source = "sim".into();
+        cfg.ais_udp_addr = Some("127.0.0.1:9200".into());
+        assert_eq!(ais_bind_addr(&cfg).as_deref(), Some("127.0.0.1:9200"));
+    }
+
+    #[test]
+    fn ais_ingest_receives_encoded_sentence() {
+        let profile_dir = maritime_profile_dir();
+        let ingest = AisIngest::open("127.0.0.1:19123", &profile_dir).expect("open ingest");
+        let sender = UdpSocket::bind("127.0.0.1:0").unwrap();
+        let sentence = fixture_nmea_line();
+        sender
+            .send_to(sentence.as_bytes(), "127.0.0.1:19123")
+            .unwrap();
+        std::thread::sleep(Duration::from_millis(50));
+        let frames = ingest.collect_until(Instant::now() + Duration::from_secs(1));
+        assert!(!frames.is_empty(), "expected at least one AIS frame");
+        assert!(frames[0].entities.iter().any(|e| e.id == "563012345"));
+    }
+}

--- a/edge/src/main.rs
+++ b/edge/src/main.rs
@@ -17,6 +17,7 @@ use tracing::{info, warn};
 
 mod config;
 mod db;
+mod ingest_ais;
 mod sim;
 mod storage;
 mod zkp;
@@ -82,8 +83,23 @@ async fn main() -> Result<()> {
             None
         };
 
-    // ── Pipeline state ────────────────────────────────────────────────────
-    let scenario = sim::Scenario::from_profile(&config.profile);
+    // ── Entity source (sim vs live AIS UDP) ───────────────────────────────
+    let ais_ingest = match ingest_ais::ais_bind_addr(&config) {
+        Some(addr) => {
+            let ingest = ingest_ais::AisIngest::open(&addr, &profile_path)?;
+            info!(%addr, "AIS UDP ingest enabled (recorded or live NMEA)");
+            Some(ingest)
+        }
+        None => {
+            info!(source = %config.source, "Synthetic sim ingest");
+            None
+        }
+    };
+    let scenario = ais_ingest
+        .as_ref()
+        .map(|_| None)
+        .unwrap_or_else(|| Some(sim::Scenario::from_profile(&config.profile)));
+
     let cycle_dur = Duration::from_secs(config.cycle_interval_secs);
     let hb_interval = Duration::from_secs(config.heartbeat_interval_secs);
 
@@ -99,14 +115,22 @@ async fn main() -> Result<()> {
         .checked_sub(hb_interval)
         .unwrap_or_else(Instant::now);
 
-    info!(scenario = ?scenario, "Pipeline started");
+    info!(
+        mode = if ais_ingest.is_some() { "ais" } else { "sim" },
+        scenario = ?scenario,
+        "Pipeline started"
+    );
 
     loop {
         let cycle_start = Instant::now();
         let now_ms = now_millis();
 
-        // ── 1. Generate frames ────────────────────────────────────────────
-        let frames = sim::generate_frames(&scenario, cycle, now_ms);
+        // ── 1. Ingest frames (sim or AIS UDP) ─────────────────────────────
+        let frames = if let Some(ref ais) = ais_ingest {
+            ais.collect_until(cycle_start + cycle_dur)
+        } else {
+            sim::generate_frames(scenario.as_ref().unwrap(), cycle, now_ms)
+        };
 
         // ── 2. Evaluate rules ─────────────────────────────────────────────
         let mut cycle_events: Vec<RiskEvent> = Vec::new();
@@ -135,7 +159,7 @@ async fn main() -> Result<()> {
             // The compliance result is stored as a top-level field in the envelope —
             // no ZKP layer required for BCA certification (see docs/regulatory/sg-bca/).
             let bca_attestation: Option<GreenMarkAttestation> =
-                if scenario == sim::Scenario::BcaGreenMark {
+                if scenario.as_ref() == Some(&sim::Scenario::BcaGreenMark) {
                     let sv = frames
                         .iter()
                         .flat_map(|f| f.entities.iter())
@@ -157,7 +181,7 @@ async fn main() -> Result<()> {
 
             // OT cybersecurity ZKP proof (separate from BCA attestation path)
             let ot_zk_proof = ot_zkp_prover.as_ref().and_then(|prover| {
-                if scenario == sim::Scenario::OtCybersecurity {
+                if scenario.as_ref() == Some(&sim::Scenario::OtCybersecurity) {
                     let inputs = ot_sim_inputs(&config.site_id, cycle, now_ms);
                     serde_json::to_vec(&inputs).ok().and_then(|b| match prover.prove(&b) {
                         Ok(proof) => Some(proof),
@@ -197,7 +221,11 @@ async fn main() -> Result<()> {
         }
 
         // ── 4. Heartbeat ──────────────────────────────────────────────────
-        let drift = sim::drift_score(cycle);
+        let drift = if ais_ingest.is_some() {
+            0.02_f32
+        } else {
+            sim::drift_score(cycle)
+        };
         let cal = calibration_status(drift);
         let (cert, deg, rej) = quality_counts(&cycle_events);
 

--- a/profiles/sg-maritime-security/params.toml
+++ b/profiles/sg-maritime-security/params.toml
@@ -1,0 +1,8 @@
+# Singapore port reference point — Pasir Panjang Terminal area
+# (aligned with edgesentry-rs sg-maritime-security fixture, issue #138)
+[reference_point]
+lat_deg = 1.2640
+lon_deg = 103.8200
+
+[ais_gap]
+threshold_s = 480


### PR DESCRIPTION
## Summary

- Add `SOURCE=ais` / `ais://HOST:PORT` / `AIS_UDP_ADDR` to switch clarus-edge from `sim.rs` to live or replayed NMEA UDP (`edgesentry-ingest::AisAdapter`).
- Add `profiles/sg-maritime-security/params.toml` (port reference + AIS gap threshold, aligned with edgesentry-rs fixture).
- Add `edge/demo/rpi5_swap_benchmark.sh` — 60s duty cycle with `nmea_udp_replay.py` + CPU/RSS sampling (compare with `edgesentry-rs/demo/rpi5_live_ais_benchmark.sh`).

## Test plan

- [x] `cargo test -p clarus-edge` (includes `ingest_ais` UDP round-trip against `sg-strait-15min.nmea`)
- [ ] On RPi5 aarch64: `./edge/demo/rpi5_swap_benchmark.sh` (blocked on hardware / #137 DuckDB)
- [ ] Confirm ≥1 `RESTRICTED_ZONE_APPROACH` or `AIS_TRACK_GAP` from replay
- [ ] Update `edgesentry-commercial` `c2-annex-a.md` after hardware numbers

## Depends on

- edgesentry-rs#404 / PR #405 (NMEA tools + fixture) — merged

Closes #138 (software path); RPi5 measurement + commercial doc update remain post-merge checklist items on the issue.


Made with [Cursor](https://cursor.com)